### PR TITLE
Fix #28 Add-PoolMember with an existing node fails

### DIFF
--- a/Private/Add-ObjectDetail.ps1
+++ b/Private/Add-ObjectDetail.ps1
@@ -98,7 +98,7 @@
     .LINK
         https://raw.githubusercontent.com/RamblingCookieMonster/PSStash/master/PSStash/Private/Add-ObjectDetail.ps1
     #>
-    [CmdletBinding()] 
+    [cmdletBinding()] 
     param(
            [Parameter( Mandatory = $false,
                        Position=0,

--- a/Public/Add-PoolMember.ps1
+++ b/Public/Add-PoolMember.ps1
@@ -27,7 +27,7 @@
         [string]$Name,
         [Parameter(Mandatory=$true)]
         $PortNumber,
-	
+    
         [ValidateSet("Enabled","Disabled")]
         [Parameter(Mandatory=$true)]$Status
     )
@@ -36,10 +36,10 @@
         Test-F5Session($F5Session)
 
         $ComputerName = $Address
-		$ip = [IPAddress]::Any
+        $ip = [IPAddress]::Any
         if ([IpAddress]::TryParse($Address,[ref]$ip)) {
-			$Address = $ip.IpAddressToString
-		} else {
+            $Address = $ip.IpAddressToString
+        } else {
             $Address = Get-CimInstance -ComputerName $Address -Class Win32_NetworkAdapterConfiguration -ErrorAction SilentlyContinue | Where-Object DefaultIPGateway | Select-Object -exp IPaddress | Select-Object -first 1
             #If we don't get an IP address for the computer, then fail
             If (!($Address)){

--- a/Public/Add-PoolMember.ps1
+++ b/Public/Add-PoolMember.ps1
@@ -63,15 +63,15 @@
                                     $Partition = $pool.partition 
                                 }
                                 $JSONBody = @{name=$Name;partition=$Partition;address=$Address;description=$ComputerName} | ConvertTo-Json
-                                $MembersLink = $F5session.GetLink($pool.membersReference.link)
-                                Invoke-RestMethodOverride -Method POST -Uri "$MembersLink" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add $ComputerName to $PoolName." | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'
+                                $MembersLink = $F5Session.GetLink($pool.membersReference.link)
+                                Invoke-RestMethodOverride -Method POST -Uri "$MembersLink" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add $ComputerName to $PoolName." | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'
 
                                 #After adding to the pool, make sure the member status is set as specified
                                 If ($Status -eq "Enabled"){
-                                    $pool | Get-PoolMember -F5Session $F5Session -Address $Address -Name $Name | Enable-PoolMember -F5session $F5session 
+                                    $pool | Get-PoolMember -F5Session $F5Session -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session 
                                 }
                                 ElseIf ($Status -eq "Disabled"){
-                                    $pool | Get-PoolMember -F5Session $F5Session -Address $Address -Name $Name | Disable-PoolMember -F5session $F5session 
+                                    $pool | Get-PoolMember -F5Session $F5Session -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session 
                                 }
                             }
                         }

--- a/Public/Add-PoolMember.ps1
+++ b/Public/Add-PoolMember.ps1
@@ -37,6 +37,9 @@
         [Parameter(Mandatory=$true)]
         [ValidateRange(0,65535)]
         [int]$PortNumber,
+    
+        [Parameter(Mandatory=$false)]
+        [string]$Description=$ComputerName,
 
         [ValidateSet("Enabled","Disabled")]
         [Parameter(Mandatory=$true)]$Status
@@ -63,13 +66,21 @@
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
                             if (!$Name) {
-                                $Name = $Address.IPAddressToString + ":" + $PortNumber
+                                $Name = '{0}:{1}' -f $Address.IPAddressToString,$PortNumber
+                            }
+                            if ($Name -notmatch ':\d+$') {
+                                $Name = '{0}:{1}' -f $Name,$PortNumber
                             }
                             foreach($pool in $InputObject) {
                                 if (!$Partition) {
                                     $Partition = $pool.partition 
                                 }
-                                $JSONBody = @{name=$Name;partition=$Partition;address=$Address.IPAddressToString;description=$ComputerName} | ConvertTo-Json
+                                $JSONBody = @{name=$Name;partition=$Partition;address=$Address.IPAddressToString;description=$Description}
+                                if (Test-Node -F5Session $F5Session -Name $Address -Partition $Partition) {
+                                    # Node exists, just add using name
+                                    $JSONBody = @{name=$Name}
+                                } # else the node will be created
+                                $JSONBody = $JSONBody | ConvertTo-Json
                                 $MembersLink = $F5session.GetLink($pool.membersReference.link)
                                 Invoke-RestMethodOverride -Method POST -Uri "$MembersLink" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add $Name to $($pool.name)." | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'
 

--- a/Public/Add-PoolMonitor.ps1
+++ b/Public/Add-PoolMonitor.ps1
@@ -33,12 +33,12 @@
                         monitor=(($($_.monitor.Trim() -split ' and ') + $Monitor | Where-Object { $_ } | Select-Object -Unique) -join ' and ')
                     } | ConvertTo-Json
                     $JSONBody
-                    $URI = $F5session.GetLink($InputObject.selfLink)
-                    Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json'
+                    $URI = $F5Session.GetLink($InputObject.selfLink)
+                    Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json'
                 }
             }
             PoolName {
-                Get-Pool -F5Session $F5session -Name $Name -Partition $Partition | Add-PoolMonitor -F5Session $F5Session -Monitor $Monitor 
+                Get-Pool -F5Session $F5Session -Name $Name -Partition $Partition | Add-PoolMonitor -F5Session $F5Session -Monitor $Monitor 
             }
         }
     }

--- a/Public/Add-PoolMonitor.ps1
+++ b/Public/Add-PoolMonitor.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Add a health monitor to a pool 
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
 

--- a/Public/Add-iRuleToVirtualServer.ps1
+++ b/Public/Add-iRuleToVirtualServer.ps1
@@ -5,6 +5,7 @@
 .NOTES
     This function defaults to the /Common partition
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
         
@@ -21,11 +22,11 @@
         [Parameter(Mandatory=$true)]
         [string]$iRuleName
     )
-    process {
-
+    begin {
         #Test that the F5 session is in a valid format
         Test-F5Session($F5Session)
-
+    }
+    process {
         switch($PSCmdLet.ParameterSetName) {
             InputObject {
 

--- a/Public/Add-iRuleToVirtualServer.ps1
+++ b/Public/Add-iRuleToVirtualServer.ps1
@@ -33,7 +33,7 @@
                 $iRulePartitionAndName = "/$Partition/$iRuleName"
 
                 #Verify that the iRule exists on the F5 LTM
-                $iRule = Get-iRule -F5session $F5session -Name $iRuleName -Partition $Partition
+                $iRule = Get-iRule -F5session $F5Session -Name $iRuleName -Partition $Partition
                 If ($iRule -eq $null){
                     Write-Error "The $iRuleName iRule does not exist in this F5 LTM."
                     $false
@@ -55,11 +55,11 @@
                         Else {
                             $iRules += $iRulePartitionAndName #$iRuleName
 
-                            $Uri = $F5Session.GetLink($virtualServer.selfLink)
+                            $URI = $F5Session.GetLink($virtualServer.selfLink)
 
                             $JSONBody = @{rules=$iRules} | ConvertTo-Json
 
-                            Invoke-RestMethodOverride -Method PUT -Uri "$Uri" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add the $iRuleName iRule to the $Name virtual server." -AsBoolean 
+                            Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add the $iRuleName iRule to the $Name virtual server." -AsBoolean 
                         }
                     }
                 }

--- a/Public/Deprecated/Get-iRuleCollection.ps1
+++ b/Public/Deprecated/Get-iRuleCollection.ps1
@@ -4,7 +4,7 @@
     Retrieve specified iRule(s)
 #>
     param(
-        $F5session=$Script:F5Session
+        $F5Session=$Script:F5Session
     )
     Write-Warning "Get-iRuleCollection is deprecated.  Please use Get-iRule"
     Get-iRule -F5session $F5Session

--- a/Public/Disable-PoolMember.ps1
+++ b/Public/Disable-PoolMember.ps1
@@ -4,6 +4,7 @@
     Disable a pool member in the specified pools
     If no pool is specified, the member will be disabled in all pools
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
 

--- a/Public/Disable-PoolMember.ps1
+++ b/Public/Disable-PoolMember.ps1
@@ -36,7 +36,7 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Disable-PoolMember -F5session $f5
+                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {
@@ -55,7 +55,7 @@
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Disable-PoolMember -F5session $f5
+                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session
             }
         }
     }

--- a/Public/Disable-PoolMember.ps1
+++ b/Public/Disable-PoolMember.ps1
@@ -37,7 +37,7 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session
+                            $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {
@@ -49,14 +49,14 @@
                         }
                         $JSONBody = @{state=$AcceptNewConnections;session='user-disabled'} | ConvertTo-Json
                         foreach($member in $InputObject) {
-                            $URI = $F5session.GetLink($member.selfLink)
-                            Invoke-RestMethodOverride -Method Put -Uri "$URI" -Credential $F5session.Credential -Body $JSONBody -ErrorMessage "Failed to disable $Address in the $PoolName pool." -AsBoolean
+                            $URI = $F5Session.GetLink($member.selfLink)
+                            Invoke-RestMethodOverride -Method Put -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to disable $Address in the $PoolName pool." -AsBoolean
                         }
                     }
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session
+                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session
             }
         }
     }

--- a/Public/Enable-PoolMember.ps1
+++ b/Public/Enable-PoolMember.ps1
@@ -29,7 +29,7 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Enable-PoolMember -F5session $f5
+                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {
@@ -42,7 +42,7 @@
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Enable-PoolMember -F5session $f5
+                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session
             }
         }
     }

--- a/Public/Enable-PoolMember.ps1
+++ b/Public/Enable-PoolMember.ps1
@@ -30,20 +30,20 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session
+                            $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {
                         $JSONBody = @{state='user-up';session='user-enabled'} | ConvertTo-Json
                         foreach($member in $InputObject) {
-                            $URI = $F5session.GetLink($member.selfLink)
-                            Invoke-RestMethodOverride -Method Put -Uri "$URI" -Credential $F5session.Credential -Body $JSONBody -ErrorMessage "Failed to enable $Address in the $PoolName pool." -AsBoolean
+                            $URI = $F5Session.GetLink($member.selfLink)
+                            Invoke-RestMethodOverride -Method Put -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable $Address in the $PoolName pool." -AsBoolean
                         }
                     }
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session
+                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session
             }
         }
     }

--- a/Public/Enable-PoolMember.ps1
+++ b/Public/Enable-PoolMember.ps1
@@ -4,6 +4,7 @@
     Enable a pool member in the specified pools
     If no pool is specified, the member will be enabled in all pools
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
 

--- a/Public/Get-CurrentConnectionCount.ps1
+++ b/Public/Get-CurrentConnectionCount.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Get the count of the specified pool member's current connections
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
 

--- a/Public/Get-CurrentConnectionCount.ps1
+++ b/Public/Get-CurrentConnectionCount.ps1
@@ -30,12 +30,12 @@
     process {
         switch($PSCmdLet.ParameterSetName) {
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Get-CurrentConnectionCount -F5Session $F5Session -Address $Address -Name $Name
+                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Get-CurrentConnectionCount -F5Session $F5Session -Address $Address -Name $Name
             }
             InputObject {
                 $InputObject | ForEach-Object {
-                    $StatsLink = $F5session.GetLink(($_.selfLink -replace '\?','/stats?'))
-                    $JSON = Invoke-RestMethodOverride -Method Get -Uri $StatsLink -Credential $F5session.Credential
+                    $StatsLink = $F5Session.GetLink(($_.selfLink -replace '\?','/stats?'))
+                    $JSON = Invoke-RestMethodOverride -Method Get -Uri $StatsLink -Credential $F5Session.Credential
                     # TODO: Establish a type for formatting and return more columns, and consider adding a GetStats() ScriptMethod to PoshLTM.PoolMember  
                     ($JSON.entries,$JSON -ne $null)[0] | Select-Object -ExpandProperty 'serverside.curConns' #| Add-ObjectDetail -TypeName PoshLTM.PoolMemberStats
                 }

--- a/Public/Get-F5Status.ps1
+++ b/Public/Get-F5Status.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS                                                                          
     Test whether the specified F5 is currently in active or standby failover mode
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session
     )

--- a/Public/Get-HealthMonitor.ps1
+++ b/Public/Get-HealthMonitor.ps1
@@ -5,6 +5,7 @@
 .NOTES
     Health monitor names are case-specific.
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$false,ValueFromPipeline=$true)]

--- a/Public/Get-HealthMonitor.ps1
+++ b/Public/Get-HealthMonitor.ps1
@@ -23,14 +23,14 @@
         $TypeSearchErrorAction = 'Continue'
         if ([string]::IsNullOrEmpty($Type)) {
             $TypeSearchErrorAction = 'SilentlyContinue'
-            $Type = Get-HealthMonitorType -F5Session $F5session
+            $Type = Get-HealthMonitorType -F5Session $F5Session
         }
     }
     process {
         foreach ($t in $Type) {
             foreach ($n in $Name) {
-                $URI = $F5session.BaseURL + 'monitor/{0}/{1}' -f $t,(Get-ItemPath -Name $n -Partition $Partition)
-                $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5session.Credential -ErrorAction $TypeSearchErrorAction
+                $URI = $F5Session.BaseURL + 'monitor/{0}/{1}' -f $t,(Get-ItemPath -Name $n -Partition $Partition)
+                $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorAction $TypeSearchErrorAction
                 if ($JSON.items -or $JSON.defaultsFrom) {
                     ($JSON.items,$JSON -ne $null)[0] |
                         Add-Member -MemberType NoteProperty -Name type -Value $t -PassThru | Add-ObjectDetail -TypeName 'PoshLTM.HealthMonitor'

--- a/Public/Get-HealthMonitorType.ps1
+++ b/Public/Get-HealthMonitorType.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Get a list of all health monitor types for the specified F5 LTM
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session        
     )

--- a/Public/Get-HealthMonitorType.ps1
+++ b/Public/Get-HealthMonitorType.ps1
@@ -11,8 +11,8 @@
     Test-F5Session($F5Session)
 
     #Only retrieve the Health monitor types
-    $Uri = $F5session.BaseURL + "monitor/"
+    $URI = $F5Session.BaseURL + "monitor/"
 
-    $monitors = Invoke-RestMethodOverride -Method Get -Uri $Uri -Credential $F5session.Credential -ErrorMessage "Failed to get the list of healt monitor types."
+    $monitors = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorMessage "Failed to get the list of healt monitor types."
     $monitors.items.reference | ForEach-Object { [Regex]::Match($_.Link,'(?<=/)[^/?]*(?=\?)').Value }
 }

--- a/Public/Get-Pool.ps1
+++ b/Public/Get-Pool.ps1
@@ -24,8 +24,8 @@
     }
     process {
         foreach ($poolname in $Name) {
-            $Uri = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $poolname -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $Uri -Credential $F5Session.Credential -ErrorMessage "Failed to get the /$Partition*/$PoolName*' pool(s)."
+            $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $poolname -Partition $Partition)
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorMessage "Failed to get the /$Partition*/$PoolName*' pool(s)."
             ($JSON.items,$JSON -ne $null)[0] | Add-ObjectDetail -TypeName 'PoshLTM.Pool'
         }
     }

--- a/Public/Get-PoolMember.ps1
+++ b/Public/Get-PoolMember.ps1
@@ -55,8 +55,8 @@
                     $InputObject = Get-Pool -F5Session $F5Session
                 }
                 foreach($pool in $InputObject) {
-                    $MembersLink = $F5session.GetLink($pool.membersReference.link)
-                    $JSON = Invoke-RestMethodOverride -Method Get -Uri $MembersLink -Credential $F5session.Credential
+                    $MembersLink = $F5Session.GetLink($pool.membersReference.link)
+                    $JSON = Invoke-RestMethodOverride -Method Get -Uri $MembersLink -Credential $F5Session.Credential
                     ($JSON.items,$JSON -ne $null)[0] | Where-Object { $_.address -like $Address -and $_.name -like $Name } | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'
                 }
             }

--- a/Public/Get-PoolMember.ps1
+++ b/Public/Get-PoolMember.ps1
@@ -41,7 +41,7 @@
                     }
                 }
             }
-		}
+        }
     }
     process {
         switch($PSCmdLet.ParameterSetName) {

--- a/Public/Get-PoolMonitor.ps1
+++ b/Public/Get-PoolMonitor.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Get details about the specified pool monitor
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
 

--- a/Public/Get-PoolMonitor.ps1
+++ b/Public/Get-PoolMonitor.ps1
@@ -28,7 +28,7 @@
                 $InputObject | ForEach-Object { ($_ | Select-Object -ExpandProperty monitor) -split ' and ' }
             }
             PoolName {
-                Get-Pool -F5Session $F5session -Name $Name -Partition $Partition | Get-PoolMonitor -F5Session $F5Session 
+                Get-Pool -F5Session $F5Session -Name $Name -Partition $Partition | Get-PoolMonitor -F5Session $F5Session 
             }
         }
     }

--- a/Public/Get-PoolsForMember.ps1
+++ b/Public/Get-PoolsForMember.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Determine which pool(s) a server is in
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$true,ParameterSetName='InputObject',ValueFromPipeline=$true)]

--- a/Public/Get-PoolsForMember.ps1
+++ b/Public/Get-PoolsForMember.ps1
@@ -21,9 +21,9 @@
     process {
         switch($PSCmdLet.ParameterSetName) {
             Address {
-                $pools = Get-Pool -F5Session $F5session
+                $pools = Get-Pool -F5Session $F5Session
                 foreach ($pool in $pools) {
-                    $members = $pool | Get-PoolMember -F5session $F5session | Where-Object { $_.address -like $Address }
+                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $_.address -like $Address }
                     if ($members) {
                         $pool
                     }    

--- a/Public/Get-StatusShape.ps1
+++ b/Public/Get-StatusShape.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Determine the shape to display for a member's current state and session values
 #>
+    [cmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]$state,
         [Parameter(Mandatory=$true)]$session

--- a/Public/Get-VirtualServer.ps1
+++ b/Public/Get-VirtualServer.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
     Retrieve the specified virtual server
 #>
-
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Alias("VirtualServerName")]

--- a/Public/Get-VirtualServer.ps1
+++ b/Public/Get-VirtualServer.ps1
@@ -22,8 +22,8 @@
     }
     process {
         foreach ($virtualserver in $Name) {
-            $Uri = $F5session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $virtualserver -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5session.Credential
+            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $virtualserver -Partition $Partition)
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
             if ($JSON.items -or $JSON.name) {
                 ($JSON.items,$JSON -ne $null)[0] | Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
             }

--- a/Public/Get-iRule.ps1
+++ b/Public/Get-iRule.ps1
@@ -7,7 +7,7 @@
 #>
     [cmdletBinding()]
     param(
-        $F5session=$Script:F5Session,
+        $F5Session=$Script:F5Session,
         
         [Alias("iRuleName")]
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
@@ -18,14 +18,14 @@
     )
     begin {
         #Test that the F5 session is in a valid format
-        Test-F5Session($F5session)
+        Test-F5Session($F5Session)
         
         Write-Verbose "NB: iRule names are case-specific."
     }
     process {
         foreach ($rulename in $Name) {
-            $Uri = $F5session.BaseURL + 'rule/{0}' -f (Get-ItemPath -Name $rulename -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $Uri -Credential $F5session.Credential -ErrorMessage "Failed to get the /$Partition*/$rulename*' iRule(s)."
+            $URI = $F5Session.BaseURL + 'rule/{0}' -f (Get-ItemPath -Name $rulename -Partition $Partition)
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorMessage "Failed to get the /$Partition*/$rulename*' iRule(s)."
             ($JSON.items,$JSON -ne $null)[0] | Add-ObjectDetail -TypeName 'PoshLTM.iRule'
         }
     }

--- a/Public/Get-iRule.ps1
+++ b/Public/Get-iRule.ps1
@@ -20,7 +20,7 @@
         #Test that the F5 session is in a valid format
         Test-F5Session($F5session)
         
-        Write-Verbose "NB: Pool names are case-specific."
+        Write-Verbose "NB: iRule names are case-specific."
     }
     process {
         foreach ($rulename in $Name) {

--- a/Public/Invoke-RestMethodOverride.ps1
+++ b/Public/Invoke-RestMethodOverride.ps1
@@ -1,4 +1,5 @@
 ﻿Function Invoke-RestMethodOverride {
+    [cmdletBinding()]
     param ( 
         [Parameter(Mandatory=$true)][string]$Method,
         [Parameter(Mandatory=$true)][string]$URI,

--- a/Public/New-F5Session.ps1
+++ b/Public/New-F5Session.ps1
@@ -7,6 +7,7 @@
     for a user with permissions to work with the REST API. Based on the scope value, it either returns the 
     session object (local scope) or adds the session object to the script scope
 #>
+    [cmdletBinding()]
     param(
         [Parameter(Mandatory=$true)][string]$LTMName,
         [Parameter(Mandatory=$true)][System.Management.Automation.PSCredential]$LTMCredentials,

--- a/Public/New-HealthMonitor.ps1
+++ b/Public/New-HealthMonitor.ps1
@@ -5,8 +5,8 @@
 
 .EXAMPLE
     New-HealthMonitor -F5Session $F5Session -Name "/Common/test123" -Type http -Receive '^HTTP.1.[0-2]\s([2|3]0[0-9])' -Send 'HEAD /host.ashx?isup HTTP/1.1\r\nHost: Test123.dyn-intl.com\r\nConnection: close\r\n\r\n'
-
 #>   
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$true)][string]$Name,

--- a/Public/New-HealthMonitor.ps1
+++ b/Public/New-HealthMonitor.ps1
@@ -17,10 +17,10 @@
     #Test that the F5 session is in a valid format
     Test-F5Session($F5Session)
 
-    $URI = $F5session.BaseURL + "monitor/$Type"
+    $URI = $F5Session.BaseURL + "monitor/$Type"
 
     #Check whether the specified pool already exists
-    If (Test-HealthMonitor -F5session $F5session -Name $Name -Type $Type){
+    If (Test-HealthMonitor -F5session $F5Session -Name $Name -Type $Type){
         Write-Error "The $Name pool already exists."
     }
 
@@ -34,6 +34,6 @@
         $JSONBody = @{name=$Name;partition=$Partition;recv=$Receive;send=$Send;interval=5;timeout=16}
         $JSONBody = $JSONBody | ConvertTo-Json
 
-        Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to create the $Name health monitor." -AsBoolean
+        Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to create the $Name health monitor." -AsBoolean
     }
 }

--- a/Public/New-Pool.ps1
+++ b/Public/New-Pool.ps1
@@ -22,10 +22,10 @@
     #Test that the F5 session is in a valid format
     Test-F5Session($F5Session)
 
-    $URI = ($F5session.BaseURL + "pool")
+    $URI = ($F5Session.BaseURL + "pool")
 
     #Check whether the specified pool already exists
-    If (Test-Pool -F5session $F5session -PoolName $PoolName){
+    If (Test-Pool -F5session $F5Session -PoolName $PoolName){
         Write-Error "The $PoolName pool already exists."
     }
 
@@ -72,7 +72,7 @@
         $JSONBody.members = $Members
         $JSONBody = $JSONBody | ConvertTo-Json
 
-        Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage ("Failed to create the $PoolName pool.") -AsBoolean
+        Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage ("Failed to create the $PoolName pool.") -AsBoolean
     }
 
 }

--- a/Public/New-Pool.ps1
+++ b/Public/New-Pool.ps1
@@ -12,6 +12,7 @@
     New-Pool -F5Session $F5Session -PoolName "MyPoolName" -MemberDefinitionList @("Server1,80,Web server","Server2,443,Another web server")
 
 #>   
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$true)][string]$PoolName,

--- a/Public/New-VirtualServer.ps1
+++ b/Public/New-VirtualServer.ps1
@@ -24,10 +24,10 @@
     #Test that the F5 session is in a valid format
     Test-F5Session($F5Session)
 
-    $URI = ($F5session.BaseURL + "virtual")
+    $URI = ($F5Session.BaseURL + "virtual")
 
     #Check whether the specified virtual server already exists
-    If (Test-VirtualServer -F5session $F5session -VirtualServerName $VirtualServerName){
+    If (Test-VirtualServer -F5session $F5Session -VirtualServerName $VirtualServerName){
         Write-Error "The $VirtualServerName virtual server already exists."
     }
 

--- a/Public/New-VirtualServer.ps1
+++ b/Public/New-VirtualServer.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Create a new virtual server
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$false)]$Kind="tm:ltm:virtual:virtualstate",

--- a/Public/Remove-HealthMonitor.ps1
+++ b/Public/Remove-HealthMonitor.ps1
@@ -5,7 +5,7 @@
 .NOTES
     Health monitor names are case-specific.
 #>
-    [cmdletBinding()]
+    [cmdletBinding( SupportsShouldProcess=$true, ConfirmImpact="Low")]    
     param(
         $F5Session=$Script:F5Session,
 

--- a/Public/Remove-HealthMonitor.ps1
+++ b/Public/Remove-HealthMonitor.ps1
@@ -26,7 +26,7 @@
     begin {
         #Test that the F5 session is in a valid format
         Test-F5Session($F5Session)
-	
+    
         Write-Verbose "NB: Health monitor names are case-specific."
         if ([string]::IsNullOrEmpty($Type)) {
             $Type = Get-HealthMonitorType -F5Session $F5session

--- a/Public/Remove-HealthMonitor.ps1
+++ b/Public/Remove-HealthMonitor.ps1
@@ -29,7 +29,7 @@
     
         Write-Verbose "NB: Health monitor names are case-specific."
         if ([string]::IsNullOrEmpty($Type)) {
-            $Type = Get-HealthMonitorType -F5Session $F5session
+            $Type = Get-HealthMonitorType -F5Session $F5Session
         }
     }
     process {
@@ -37,13 +37,13 @@
             InputObject {
                 foreach($monitor in $InputObject) {
                     if ($pscmdlet.ShouldProcess($monitor.fullPath)){
-                        $URI = $F5session.GetLink($monitor.selfLink)
-                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5session.Credential -AsBoolean
+                        $URI = $F5Session.GetLink($monitor.selfLink)
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential -AsBoolean
                     }
                 }
             }
             Name {
-                Get-HealthMonitor -F5Session $F5Session -Name $Name -Type $Type -Partition $Partition | Remove-HealthMonitor -F5session $F5session
+                Get-HealthMonitor -F5Session $F5Session -Name $Name -Type $Type -Partition $Partition | Remove-HealthMonitor -F5session $F5Session
             }
         }
     }

--- a/Public/Remove-HealthMonitor.ps1
+++ b/Public/Remove-HealthMonitor.ps1
@@ -43,7 +43,7 @@
                 }
             }
             Name {
-                Get-HealthMonitor -F5Session $f5 -Name $Name -Type $Type -Partition $Partition | Remove-HealthMonitor -F5session $F5session
+                Get-HealthMonitor -F5Session $F5Session -Name $Name -Type $Type -Partition $Partition | Remove-HealthMonitor -F5session $F5session
             }
         }
     }

--- a/Public/Remove-Pool.ps1
+++ b/Public/Remove-Pool.ps1
@@ -5,9 +5,7 @@
 .NOTES
     Pool names are case-specific.
 #>
-
-    [CmdletBinding( SupportsShouldProcess=$true, ConfirmImpact="High")]    
-
+    [cmdletBinding( SupportsShouldProcess=$true, ConfirmImpact="High")]    
     param (
         $F5Session=$Script:F5Session,
         

--- a/Public/Remove-Pool.ps1
+++ b/Public/Remove-Pool.ps1
@@ -34,8 +34,8 @@
             InputObject {
                 foreach($pool in $InputObject) {
                     if ($pscmdlet.ShouldProcess($pool.fullPath)){
-                        $URI = $F5session.GetLink($pool.selfLink)
-                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5session.Credential -AsBoolean
+                        $URI = $F5Session.GetLink($pool.selfLink)
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential -AsBoolean
                     }
                 }
             }

--- a/Public/Remove-PoolMember.ps1
+++ b/Public/Remove-PoolMember.ps1
@@ -33,7 +33,7 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Remove-PoolMember -F5session $f5
+                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Remove-PoolMember -F5session $F5session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {
@@ -47,7 +47,7 @@
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Remove-PoolMember -F5session $f5
+                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Remove-PoolMember -F5session $F5session
             }
         }
     }

--- a/Public/Remove-PoolMember.ps1
+++ b/Public/Remove-PoolMember.ps1
@@ -33,21 +33,21 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Remove-PoolMember -F5session $F5session
+                            $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Remove-PoolMember -F5session $F5Session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {
                         foreach($member in $InputObject) {
                             if ($pscmdlet.ShouldProcess($member.fullPath)){
-                                $URI = $F5session.GetLink($member.selfLink)
-                                Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5session.Credential -AsBoolean
+                                $URI = $F5Session.GetLink($member.selfLink)
+                                Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential -AsBoolean
                             }
                         }
                     }
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Remove-PoolMember -F5session $F5session
+                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Remove-PoolMember -F5session $F5Session
             }
         }
     }

--- a/Public/Remove-PoolMonitor.ps1
+++ b/Public/Remove-PoolMonitor.ps1
@@ -23,7 +23,7 @@
     begin {
         #Test that the F5 session is in a valid format
         Test-F5Session($F5Session)
-	
+
         Write-Verbose "NB: Health monitor names are case-specific."
     }
     process {

--- a/Public/Remove-PoolMonitor.ps1
+++ b/Public/Remove-PoolMonitor.ps1
@@ -40,7 +40,7 @@
                 }
             }
             PoolName {
-                Get-Pool -F5session $F5session -PoolName $PoolName -Partition $Partition | Remove-PoolMonitor -F5session $f5 -Name $Name
+                Get-Pool -F5session $F5session -PoolName $PoolName -Partition $Partition | Remove-PoolMonitor -F5session $F5session -Name $Name
             }
         }
     }

--- a/Public/Remove-PoolMonitor.ps1
+++ b/Public/Remove-PoolMonitor.ps1
@@ -6,7 +6,7 @@
     [cmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="Medium")]    
     param(
         [Parameter(Mandatory=$true)]
-        $F5session,
+        $F5Session,
 
         [Parameter(Mandatory=$true,ParameterSetName='InputObject',ValueFromPipeline=$true)]
         [Alias('Pool')]
@@ -34,13 +34,13 @@
 
                         $monitor = ($pool.monitor -split ' and ' | Where-Object { $_.Trim() -ne $Name }) -join ' and '
                         $JSONBody = @{monitor=$monitor} | ConvertTo-Json
-                        $URI = $F5session.GetLink($pool.selfLink)
-                        Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json'
+                        $URI = $F5Session.GetLink($pool.selfLink)
+                        Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json'
                     }
                 }
             }
             PoolName {
-                Get-Pool -F5session $F5session -PoolName $PoolName -Partition $Partition | Remove-PoolMonitor -F5session $F5session -Name $Name
+                Get-Pool -F5session $F5Session -PoolName $PoolName -Partition $Partition | Remove-PoolMonitor -F5session $F5Session -Name $Name
             }
         }
     }

--- a/Public/Remove-PoolMonitor.ps1
+++ b/Public/Remove-PoolMonitor.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Removes a health monitor from a pool 
 #>
+    [cmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="Medium")]    
     param(
         [Parameter(Mandatory=$true)]
         $F5session,

--- a/Public/Remove-ProfileRamCache.ps1
+++ b/Public/Remove-ProfileRamCache.ps1
@@ -5,6 +5,7 @@
 .NOTES
     Example profile: "profile/http/ramcache"
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$true)]$ProfileName

--- a/Public/Remove-ProfileRamCache.ps1
+++ b/Public/Remove-ProfileRamCache.ps1
@@ -14,8 +14,8 @@
     #Test that the F5 session is in a valid format
     Test-F5Session($F5Session)
 
-    $ProfileURL = $F5session.BaseURL +$ProfileName
+    $ProfileURL = $F5Session.BaseURL +$ProfileName
 
-    Invoke-RestMethodOverride -Method DELETE -Uri "$ProfileURL" -Credential $F5session.Credential -ErrorMessage "Failed to clear the ram cache for the $ProfileName profile." |
+    Invoke-RestMethodOverride -Method DELETE -Uri "$ProfileURL" -Credential $F5Session.Credential -ErrorMessage "Failed to clear the ram cache for the $ProfileName profile." |
         Out-Null
 }

--- a/Public/Remove-VirtualServer.ps1
+++ b/Public/Remove-VirtualServer.ps1
@@ -5,8 +5,7 @@
 .NOTES
     Virtual server names are case-specific.
 #>
-    [CmdletBinding( SupportsShouldProcess=$true, ConfirmImpact="High")]    
-
+    [cmdletBinding( SupportsShouldProcess=$true, ConfirmImpact="High")]    
     param (
         $F5Session=$Script:F5Session,
         

--- a/Public/Remove-VirtualServer.ps1
+++ b/Public/Remove-VirtualServer.ps1
@@ -28,13 +28,13 @@
     process {
         switch($PSCmdLet.ParameterSetName) {
             Name {
-                $Name | Get-VirtualServer -F5Session $F5session -Partition $Partition | Remove-VirtualServer -F5session $F5Session
+                $Name | Get-VirtualServer -F5Session $F5Session -Partition $Partition | Remove-VirtualServer -F5session $F5Session
             }
             InputObject {
                 foreach($virtualserver in $InputObject) {
                     if ($pscmdlet.ShouldProcess($virtualserver.fullPath)){
-                        $URI = $F5session.GetLink($virtualserver.selfLink)
-                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5session.Credential -AsBoolean
+                        $URI = $F5Session.GetLink($virtualserver.selfLink)
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential -AsBoolean
                     }
                 }
             }

--- a/Public/Remove-iRuleFromVirtualServer.ps1
+++ b/Public/Remove-iRuleFromVirtualServer.ps1
@@ -5,6 +5,7 @@
 .NOTES
     This function defaults to the /Common partition
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
 
@@ -21,11 +22,11 @@
         [Parameter(Mandatory=$true)]
         [string]$iRuleName
     )
-    process {
-
+    begin {
         #Test that the F5 session is in a valid format
         Test-F5Session($F5Session)
-
+    }
+    process {
         switch($PSCmdLet.ParameterSetName) {
             InputObject {
 

--- a/Public/Remove-iRuleFromVirtualServer.ps1
+++ b/Public/Remove-iRuleFromVirtualServer.ps1
@@ -45,11 +45,11 @@
 
                         $iRules = $iRules | Where-Object { $_ -ne $iRulePartitionAndName }
 
-                        $Uri = $F5Session.GetLink($virtualServer.selfLink)
+                        $URI = $F5Session.GetLink($virtualServer.selfLink)
 
                         $JSONBody = @{rules=$iRules} | ConvertTo-Json
 
-                        Invoke-RestMethodOverride -Method PUT -Uri "$Uri" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to remove the $iRuleName iRule from the $Name virtual server." -AsBoolean 
+                        Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to remove the $iRuleName iRule from the $Name virtual server." -AsBoolean 
 
                     }
                     Else {

--- a/Public/Set-PoolMemberDescription.ps1
+++ b/Public/Set-PoolMemberDescription.ps1
@@ -33,20 +33,20 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5Session
+                            $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5Session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {
                         foreach($member in $InputObject) {
                             $JSONBody = @{description=$Description} | ConvertTo-Json
-                            $URI = $F5session.GetLink($member.selfLink)
-                            Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to set the description on $ComputerName in the $PoolName pool to $Description." -AsBoolean
+                            $URI = $F5Session.GetLink($member.selfLink)
+                            Invoke-RestMethodOverride -Method PUT -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to set the description on $ComputerName in the $PoolName pool to $Description." -AsBoolean
                         }
                     }
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5session -Description $Description
+                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5Session -Description $Description
             }
         }
     }

--- a/Public/Set-PoolMemberDescription.ps1
+++ b/Public/Set-PoolMemberDescription.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Set the description value for the specified pool member
 #>
+    [cmdletBinding()]
     param(
         $F5Session=$Script:F5Session,
 

--- a/Public/Set-PoolMemberDescription.ps1
+++ b/Public/Set-PoolMemberDescription.ps1
@@ -45,7 +45,7 @@
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $f5 -Description $Description
+                Get-PoolMember -F5session $F5session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5session -Description $Description
             }
         }
     }

--- a/Public/Set-PoolMemberDescription.ps1
+++ b/Public/Set-PoolMemberDescription.ps1
@@ -32,7 +32,7 @@
                         if (!$Address) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
-                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $f5
+                            $InputObject | Get-PoolMember -F5session $F5session -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5Session
                         }
                     }
                     "tm:ltm:pool:members:membersstate" {

--- a/Public/Sync-DeviceToGroup.ps1
+++ b/Public/Sync-DeviceToGroup.ps1
@@ -3,6 +3,7 @@
 .SYNOPSIS
     Sync the specified device to the group. This assumes the F5 session object is for the device that will be synced to the group.
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$true)]$GroupName

--- a/Public/Sync-DeviceToGroup.ps1
+++ b/Public/Sync-DeviceToGroup.ps1
@@ -12,7 +12,7 @@
     #Test that the F5 session is in a valid format
     Test-F5Session($F5Session)
 
-    $URI = $F5session.BaseURL -replace "/ltm", "/cm"
+    $URI = $F5Session.BaseURL -replace "/ltm", "/cm"
 
     $JSONBody = @{command='run';utilCmdArgs="config-sync to-group $GroupName"}
     $JSONBody = $JSONBody | ConvertTo-Json

--- a/Public/Test-F5Session.ps1
+++ b/Public/Test-F5Session.ps1
@@ -4,6 +4,7 @@ Function Test-F5Session {
 .SYNOPSIS
     Check that the F5Session object has a valid base URL and PSCredential object
 #>
+    [cmdletBinding()]
     param (
         [Parameter(Mandatory=$true)][AllowNull()]$F5Session
     )

--- a/Public/Test-F5Session.ps1
+++ b/Public/Test-F5Session.ps1
@@ -1,4 +1,3 @@
-
 Function Test-F5Session {
 <#
 .SYNOPSIS
@@ -8,10 +7,8 @@ Function Test-F5Session {
     param (
         [Parameter(Mandatory=$true)][AllowNull()]$F5Session
     )
-
-
     #Validate F5Session 
     If ($($F5Session.BaseURL) -ne ("https://$($F5Session.Name)/mgmt/tm/ltm/") -or ($F5Session.Credential.GetType().name -ne 'PSCredential')) { 
-        Throw('You must either create an F5 Session with script scope (by calling New-F5Session) or pass an F5 session to this function.') 
+        Write-Error 'You must either create an F5 Session with script scope (by calling New-F5Session) or pass an F5 session to this function.' 
     }
 }

--- a/Public/Test-HealthMonitor.ps1
+++ b/Public/Test-HealthMonitor.ps1
@@ -17,7 +17,7 @@
     Write-Verbose "NB: HealthMonitor names are case-specific."
 
     #Build the URI for this health monitor
-    $URI = $F5session.BaseURL + 'monitor/{0}/{1}' -f $Type,($Name -replace '/','~')
+    $URI = $F5Session.BaseURL + 'monitor/{0}/{1}' -f $Type,($Name -replace '/','~')
 
-    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5session.Credential -ErrorAction SilentlyContinue -AsBoolean
+    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorAction SilentlyContinue -AsBoolean
 }

--- a/Public/Test-HealthMonitor.ps1
+++ b/Public/Test-HealthMonitor.ps1
@@ -5,6 +5,7 @@
 .NOTES
     HealthMonitor names are case-specific.
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Parameter(Mandatory=$true)][string]$Name,

--- a/Public/Test-Node.ps1
+++ b/Public/Test-Node.ps1
@@ -1,0 +1,49 @@
+﻿Function Test-Node {
+<#
+.SYNOPSIS
+    Test whether the specified node(s) exist
+.NOTES
+    Node names are case-specific.
+#>
+    [cmdletBinding()]
+    param (
+        $F5Session=$Script:F5Session,
+
+        [Parameter(Mandatory=$true,ParameterSetName='Address',ValueFromPipelineByPropertyName=$true)]
+        [string[]]$Address,
+
+        [Alias('ComputerName')]
+        [Alias('NodeName')]
+        [Parameter(Mandatory=$true,ParameterSetName='Name',ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [string[]]$Name='',
+
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Partition
+    )
+    begin {
+        #Test that the F5 session is in a valid format
+        Test-F5Session($F5Session)
+
+        Write-Verbose "NB: Node names are case-specific."
+    }
+    process {
+        switch ($PSCmdlet.ParameterSetName) {
+            Address {
+                foreach ($itemaddress in $Address) {
+                    $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Partition $Partition)
+                    $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
+                    [bool](
+                        ($JSON.items,$JSON -ne $null)[0] | 
+                        Where-Object { $Address -eq '*' -or $Address -contains $_.address}
+                    )
+                }
+            }
+            Name {
+                foreach ($itemname in $Name) {
+                    $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+                    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
+                }
+            }
+        }
+    }
+}

--- a/Public/Test-Pool.ps1
+++ b/Public/Test-Pool.ps1
@@ -18,6 +18,6 @@
     Write-Verbose "NB: Pool names are case-specific."
 
     #Build the URI for this pool
-    $URI = $F5session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $Name -Partition $Partition)
-    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5session.Credential -ErrorAction SilentlyContinue -AsBoolean
+    $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $Name -Partition $Partition)
+    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorAction SilentlyContinue -AsBoolean
 }

--- a/Public/Test-Pool.ps1
+++ b/Public/Test-Pool.ps1
@@ -5,6 +5,7 @@
 .NOTES
     Pool names are case-specific.
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Alias("PoolName")]

--- a/Public/Test-VirtualServer.ps1
+++ b/Public/Test-VirtualServer.ps1
@@ -19,7 +19,7 @@
     Write-Verbose "NB: Virtual server names are case-specific."
 
     #Build the URI for this virtual server
-    $URI = $F5session.BaseURL + 'virtual/{0}' -f ($Name -replace '/','~')
+    $URI = $F5Session.BaseURL + 'virtual/{0}' -f ($Name -replace '/','~')
 
-    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5session.Credential -AsBoolean
+    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
 }

--- a/Public/Test-VirtualServer.ps1
+++ b/Public/Test-VirtualServer.ps1
@@ -3,8 +3,9 @@
 .SYNOPSIS
     Test whether the specified virtual server exists
 .NOTES
-    Pool names are case-specific.
+    Virtual server names are case-specific.
 #>
+    [cmdletBinding()]
     param (
         $F5Session=$Script:F5Session,
         [Alias("VirtualServerName")]


### PR DESCRIPTION
Test-Node used to determine if node already exists.  If so, $JSONBody
includes only the name property as suggested in  [Add a new pool with an existing node](https://devcentral.f5.com/questions/add-a-new-pool-with-an-existing-node).

Added optional -Description parameter which defaults to
$ComputerName for backward compatibility.

Includes commit 5639829.  I made these seemingly OCD changes, because while troubleshooting various functions I found myself using beyondcompare against similar functions and matching up these unimportant differences helped me isolate significant differences.