### PR TITLE
Node method additions + a few other things

### DIFF
--- a/Public/Get-Node.ps1
+++ b/Public/Get-Node.ps1
@@ -1,0 +1,32 @@
+﻿Function Get-Node {
+<#
+.SYNOPSIS
+    Retrieve the specified node
+.NOTES
+    Node names are case-specific.
+#>
+    [cmdletBinding()]
+    param (
+        [Alias("NodeName")]
+        [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [string[]]$Name='',
+        
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Partition,
+
+        $F5Session=$Script:F5Session
+    )
+    begin {
+        #Test that the F5 session is in a valid format
+        Test-F5Session($F5Session)
+        
+        Write-Verbose "NB: Node names are case-specific."
+    }
+    process {
+        foreach ($nodeName in $Name) {
+            $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $nodeName -Partition $Partition)
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorMessage "Failed to get the /$Partition*/$nodeName*' node(s)."
+            ($JSON.items,$JSON -ne $null)[0] | Add-ObjectDetail -TypeName 'PoshLTM.Node'
+        }
+    }
+}

--- a/Public/New-F5Session.ps1
+++ b/Public/New-F5Session.ps1
@@ -33,3 +33,5 @@
         $newSession
     }
 }
+
+New-Alias -Name Connect-F5Session -Value New-F5Session;

--- a/Public/New-Node.ps1
+++ b/Public/New-Node.ps1
@@ -1,0 +1,71 @@
+﻿Function New-Node {
+<#
+.SYNOPSIS
+    Create a new node.
+
+.DESCRIPTION
+    Expects $NodeAddress to be an IPAddress object. 
+    $NodeName is optional, and will default to the IPAddress is not included
+    Returns the new node definition
+
+.EXAMPLE
+    New-Node -F5Session $F5Session -Name "MyNodeName" -Address 10.0.0.1 -Description "My node description"
+
+#>   
+    [cmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true, ParameterSetName="Simple")]
+        [IPAddress]$Address,
+
+        [Parameter(Mandatory=$false, ParameterSetName="Simple")]
+        [String]$Partition="Common",
+        
+        [Parameter(Mandatory=$false, ParameterSetName="Simple")]
+        [string]$Name=$null,
+        
+        [Parameter(Mandatory=$false, ParameterSetName="Simple")]
+        [string]$Description=$null,
+        
+        [Parameter(Mandatory=$true, ParameterSetName="Full" )]
+        [PSCustomObject]$Properties=@{},
+        
+        [Switch]$PassThrough,
+
+        $F5Session=$Script:F5Session
+    )
+    begin {
+        #Test that the F5 session is in a valid format
+        Test-F5Session($F5Session)
+
+        switch ($PSCmdlet.ParameterSetName) {
+            "Simple" {
+                if ($Name -match '^[/\\](?<Partition>[^/\\]*)[/\\](?<Name>[^/\\]*)$') {
+                    $Partition = $matches['Partition']
+                    $Name = $matches['Name']
+                } else {                
+                    # Default the name to the address if not provided
+                    $Name = ($Name, "$Address", $_ -ne $null)[0]
+                }
+                $Properties = [PSCustomObject]@{name=$Name;address="$Address";partition=$Partition;description=$Description};
+            }
+            "Full" { 
+                $Name = $Properties.name;
+            }
+            default { 
+                throw "Unable to determine node properties"
+            }
+        }
+    }
+    process {
+        $URI = ($F5Session.BaseURL + "node")
+
+        #Check whether the specified node already exists
+        if (Test-Node -F5Session $F5Session -Name $Name){
+            Write-Error "The $Name node already exists."
+        } else {
+            $JSONBody = $Properties | ConvertTo-Json
+            $newNode = Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage ("Failed to create the $Name node.")
+            if ($PassThrough) { $newNode }
+        }
+    }
+}

--- a/Public/Remove-Node.ps1
+++ b/Public/Remove-Node.ps1
@@ -1,0 +1,44 @@
+﻿Function Remove-Node {
+<#
+.SYNOPSIS
+    Remove the specified node. Confirmation is needed
+.NOTES
+    Node names are case-specific.
+#>
+    [cmdletBinding( SupportsShouldProcess=$true, ConfirmImpact="High")]    
+    param (
+        [Alias('Node')]
+        [Parameter(Mandatory=$true,ParameterSetName='InputObject',ValueFromPipeline=$true)]
+        [PSObject[]]$InputObject,
+
+       
+        [Alias("NodeName")]
+        [Parameter(Mandatory=$true,ParameterSetName='Name',ValueFromPipeline=$true)]
+        [string[]]$Name,
+        [Parameter(Mandatory=$false)]
+        [string]$Partition,
+
+        $F5Session=$Script:F5Session        
+    )
+    begin {
+        #Test that the F5 session is in a valid format
+        Test-F5Session($F5Session)
+
+        Write-Verbose "NB: Node names are case-specific."
+    }
+    process {
+        switch($PSCmdLet.ParameterSetName) {
+            Name {
+                Get-Node -F5Session $F5Session -Name $Name -Partition $Partition | Remove-Node -F5session $F5Session
+            }
+            InputObject {
+                foreach($node in $InputObject) {
+                    if ($pscmdlet.ShouldProcess($node.fullPath)){
+                        $URI = $F5Session.GetLink($node.selfLink)
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Public/Rename-Node.ps1
+++ b/Public/Rename-Node.ps1
@@ -1,0 +1,50 @@
+﻿Function Rename-Node {
+<#
+.SYNOPSIS
+    Attempts to rename a node.
+
+.DESCRIPTION
+    Expects $NodeAddress to be an IPAddress object. 
+    $NodeName is optional, and will default to the IPAddress is not included
+    Returns the new node definition
+
+.EXAMPLE
+    Rename-Node -F5Session $F5Session -Name "MyNodeName" -Address 10.0.0.1 -Description "My node description"
+
+#>   
+    [cmdletBinding()]
+    param (
+        [Alias("Name")]
+        [Parameter(Mandatory=$true)]
+        [String]$NodeName,
+
+        [Alias("NewName")]
+        [Parameter(Mandatory=$false)]
+        [String]$NodeNewName,
+        
+        [Parameter(Mandatory=$false)]
+        [String]$Partition,
+        
+        $F5Session=$Script:F5Session
+    )
+    begin {
+        #Test that the F5 session is in a valid format
+        Test-F5Session($F5Session)
+    }
+    process {
+        # Get the node
+        $node = Get-Node -F5Session $F5Session -Name $NodeName;
+        Write-Verbose "Node retrieved - $($node | ConvertTo-Json -Compress)";
+
+        # Attempt to delete the node (errors if in use)
+        Remove-Node -F5Session $F5Session -InputObject $node;
+        Write-Verbose "Node removed";
+
+        # Create the new node
+        $node.name = $NodeNewName;                                                # We want to add the new object the way it was before
+        if ($node.session -like 'monitor-*') { $node.session = 'user-enabled' }   # Create fails if we try to set the session to monitor-disabled or monitor-enabled
+        $properties = $node | Select-Object * -ExcludeProperty @("selfLink", "kind", "generation", "state")
+        $newNode = New-Node -Properties $properties -PassThrough
+        Write-Verbose "Node added - $($newNode | ConvertTo-Json -Compress)";
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It requires PowerShell v3 or higher.
 It includes a Validation.cs class file (based on [code](https://www.briantist.com/errors/could-not-establish-trust-relationship-for-the-ssltls-secure-channel/) posted by Brian Scholer on [www.briantist.com](www.briantist.com)) to allow for using the REST API with LTM devices using self-signed SSL certificates.
 
 To use:
-Download all the files and place them in a F5-LTM folder beneath your PowerShell modules folder. By default, this is %USERPROFILE%\Documents\WindowsPowerShell\Modules or $env:UserProfile\Documents\WindowsPowerShell\Modules
+Download all the files and place them in a F5-LTM folder beneath your PowerShell modules folder. By default, this is `%USERPROFILE%\Documents\WindowsPowerShell\Modules` or `$env:UserProfile\Documents\WindowsPowerShell\Modules`
 
 The module contains the following functions. 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The module contains the following functions.
    * Add-iRuleToVirtualServer
    * Add-PoolMember
    * Add-PoolMonitor
+   * Connect-F5Session (Aliased to New-F5Session)
    * Disable-PoolMember
    * Enable-PoolMember
    * Get-CurrentConnectionCount
@@ -22,6 +23,7 @@ The module contains the following functions.
    * Get-HealthMonitor
    * Get-HealthMonitorType
    * Get-iRuleCollection (deprecated; Use Get-iRule)
+   * Get-Node
    * Get-Pool
    * Get-PoolList (deprecated; Use Get-Pool)
    * Get-PoolMember
@@ -38,10 +40,13 @@ The module contains the following functions.
    * Get-VirtualServerList (deprecated; Use Get-VirtualServer)
    * New-F5Session
    * New-HealthMonitor
+   * New-Node
    * New-Pool
    * New-VirtualServer
+   * Rename-Node (fails if node is in use)
    * Remove-HealthMonitor
    * Remove-iRuleFromVirtualServer
+   * Remove-Node
    * Remove-Pool
    * Remove-PoolMember
    * Remove-PoolMonitor

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It is built to work with version 11.6 and higher
 
 It requires PowerShell v3 or higher.
 
-It includes a Validation.cs class file (based on code posted by Brian Scholer on www.briantist.com) to allow for using the REST API with LTM devices using self-signed SSL certificates.
+It includes a Validation.cs class file (based on [code](https://www.briantist.com/errors/could-not-establish-trust-relationship-for-the-ssltls-secure-channel/) posted by Brian Scholer on [www.briantist.com](www.briantist.com)) to allow for using the REST API with LTM devices using self-signed SSL certificates.
 
 To use:
 Download all the files and place them in a F5-LTM folder beneath your PowerShell modules folder. By default, this is %USERPROFILE%\Documents\WindowsPowerShell\Modules or $env:UserProfile\Documents\WindowsPowerShell\Modules

--- a/TypeData/PoshLTM.Format.ps1xml
+++ b/TypeData/PoshLTM.Format.ps1xml
@@ -38,6 +38,43 @@
     <View>
       <Name>Default</Name>
       <ViewSelectedBy>
+        <TypeName>PoshLTM.Node</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+            <Label>Name</Label>
+            <Width>30</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Partition</Label>
+            <Width>20</Width>
+          </TableColumnHeader>
+          <TableColumnHeader>
+            <Label>Address</Label>
+            <Width>30</Width>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>partition</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>address</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
+      <Name>Default</Name>
+      <ViewSelectedBy>
         <TypeName>PoshLTM.Pool</TypeName>
       </ViewSelectedBy>
       <TableControl>


### PR DESCRIPTION
I've added a few methods dealing with nodes in this request
* **Get-Node**
* **Remove-Node**
* **New-Node**
* **Rename-Node** *(Note: Rename-Node basically does a Get-Node, Remove-Node, modify the name, and then New-Node currently. If the node is in use, it will fail. I've been working on a script to automatically remove nodes from pools and then re-add them after renaming it. I think 11.6 allows for object renaming, but we run 11.5 versions here, so the need is still there for us.*

Another small addition was to add an alias for the `New-F5Sesson` command to allow `Connect-F5Session` as well (personal preference, but figured I'd include it)