### PR TITLE
PowerShell .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+*.md            text
+*.gitattributes text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.cs    text  eol=crlf
+*.ps1    text  eol=crlf
+*.psm1   text  eol=crlf
+*.psd1   text  eol=crlf
+*.psc1   text  eol=crlf
+*.ps1xml text  eol=crlf
+*.clixml text  eol=crlf
+*.xml    text  eol=crlf
+*.txt    text  eol=crlf

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 before_test:
   # Set FunctionsToExport and ModuleVersion in the module manifest (F5-LTM.psd1); Fixes #37 Do not export Private\*.ps1 functions
   - ps: |
-      $FunctionsToExport = ((Get-ChildItem (Join-Path $env:APPVEYOR_BUILD_FOLDER 'F5-LTM\Public') -Filter '*.ps1' -Recurse).BaseName) -join ','
+      $FunctionsToExport = ((Get-ChildItem (Join-Path $env:APPVEYOR_BUILD_FOLDER 'F5-LTM\Public') -Filter '*.ps1' -Recurse).BaseName) -join "','"
       (Get-Content (Join-Path $env:APPVEYOR_BUILD_FOLDER 'F5-LTM\F5-LTM.psd1') -Raw) -replace 
       "FunctionsToExport = '.*'","FunctionsToExport = '$FunctionsToExport'" -replace 
       "ModuleVersion = '.*'", "ModuleVersion = '$env:APPVEYOR_BUILD_VERSION'" | 


### PR DESCRIPTION
It may be that appveyor git config global defaults are using unix style line endings, which adversely impacts the published PowerShell module file's line endings.    

```PowerShell
PS C:\WINDOWS\system32> import-module -module f5-ltm
Import-Module : Cannot bind parameter 'ModuleInfo'. Cannot convert the "f5-ltm" value of type "System.String" to type "System.Management.Automation.PSModuleInfo".
At line:1 char:23
+ import-module -module f5-ltm
+                       ~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Import-Module], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.ImportModuleCommand
```

This .gitattributes file should resolve that.  Based on:
- https://gist.github.com/KirkMunro/d873a755b38a7bfa2495#file-powershell-unsigned-gitattributes
- https://help.github.com/articles/dealing-with-line-endings/