### PR TITLE
Added support for Application parameter

### DIFF
--- a/F5-LTM/Private/Get-ItemPath.ps1
+++ b/F5-LTM/Private/Get-ItemPath.ps1
@@ -15,7 +15,6 @@
             }
         } else {
             if ([string]::IsNullOrEmpty($Partition)) {
-                
                 if ([string]::IsNullOrEmpty($Application)) {
                     "~Common~$Name"
                 }

--- a/F5-LTM/Private/Get-ItemPath.ps1
+++ b/F5-LTM/Private/Get-ItemPath.ps1
@@ -1,6 +1,7 @@
 ﻿Function Get-ItemPath {
     param (
         [Parameter(Mandatory=$false)][string]$Name,
+        [Parameter(Mandatory=$false)][string]$Application,
         [Parameter(Mandatory=$false)][string]$Partition
     )
     if ($Name -match '^/.*/.*$') {
@@ -14,9 +15,20 @@
             }
         } else {
             if ([string]::IsNullOrEmpty($Partition)) {
-                "~Common~$Name"
+                
+                if ([string]::IsNullOrEmpty($Application)) {
+                    "~Common~$Name"
+                }
+                else {
+                    "~Common~$Application.app~$Name"
+                }
             } else {
-               "~$Partition~$Name"
+                if ([string]::IsNullOrEmpty($Application)) {
+                    "~$Partition~$Name"
+                }
+                else {
+                    "~$Partition~$Application.app~$Name"
+                }
             }
         }
     }

--- a/F5-LTM/Public/Disable-VirtualServer.ps1
+++ b/F5-LTM/Public/Disable-VirtualServer.ps1
@@ -11,6 +11,10 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
+        [Alias('App')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
@@ -18,7 +22,7 @@
         $JSONBody = "{`"disabled`":true}"
         
         foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to disable VirtualServer $itemname." -AsBoolean
         }
     }

--- a/F5-LTM/Public/Disable-VirtualServer.ps1
+++ b/F5-LTM/Public/Disable-VirtualServer.ps1
@@ -11,7 +11,7 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
-        [Alias('App')]
+        [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 
@@ -24,6 +24,7 @@
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to disable VirtualServer $itemname." -AsBoolean
+            Get-VirtualServer -F5Session $F5Session -Name $Name -Application $Application -Partition $Partition
         }
     }
 }

--- a/F5-LTM/Public/Enable-VirtualServer.ps1
+++ b/F5-LTM/Public/Enable-VirtualServer.ps1
@@ -11,7 +11,7 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
-        [Alias('App')]
+        [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 
@@ -24,6 +24,7 @@
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable VirtualServer $itemname." -AsBoolean
+            Get-VirtualServer -F5Session $F5Session -Name $Name -Application $Application -Partition $Partition
         }
     }
 }

--- a/F5-LTM/Public/Enable-VirtualServer.ps1
+++ b/F5-LTM/Public/Enable-VirtualServer.ps1
@@ -11,6 +11,10 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
+        [Alias('App')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
@@ -18,7 +22,7 @@
         $JSONBody = "{`"enabled`":true}"
         
         foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable VirtualServer $itemname." -AsBoolean
         }
     }

--- a/F5-LTM/Public/Get-HealthMonitor.ps1
+++ b/F5-LTM/Public/Get-HealthMonitor.ps1
@@ -13,6 +13,10 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
+        [Alias('iApp')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
         
@@ -33,7 +37,7 @@
     process {
         foreach ($typename in $Type) {
             foreach ($itemname in $Name) {
-                $URI = $F5Session.BaseURL + 'monitor/{0}' -f ($typename,(Get-ItemPath -Name $itemname -Partition $Partition) -join '/')
+                $URI = $F5Session.BaseURL + 'monitor/{0}' -f ($typename,(Get-ItemPath -Name $itemname -Application $Application -Partition $Partition) -join '/')
                 $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorAction $TypeSearchErrorAction
                 if ($JSON.items -or $JSON.name) {
                     Invoke-NullCoalescing {$JSON.items} {$JSON} |

--- a/F5-LTM/Public/Get-Pool.ps1
+++ b/F5-LTM/Public/Get-Pool.ps1
@@ -35,7 +35,3 @@
         }
     }
 }
-
-#https://ltm1.example.com/mgmt/tm/ltm/pool/~dev~sharepoint-2010-bmr-443.app~sharepoint-2010-bmr-443_pool
-
-#The URL format is $F5Session.BaseURL + '/pool/~$($Partition)~$($iApp).app~$($Pool)". It looks like Get-VirtualServer and other functions may have a similar problem.

--- a/F5-LTM/Public/Get-Pool.ps1
+++ b/F5-LTM/Public/Get-Pool.ps1
@@ -13,7 +13,7 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
-        [Alias('App')]
+        [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 

--- a/F5-LTM/Public/Get-Pool.ps1
+++ b/F5-LTM/Public/Get-Pool.ps1
@@ -13,6 +13,10 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
+        [Alias('App')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
@@ -24,10 +28,14 @@
     }
     process {
         foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
             Invoke-NullCoalescing {$JSON.items} {$JSON} |
                 Add-ObjectDetail -TypeName 'PoshLTM.Pool'
         }
     }
 }
+
+#https://ltm1.example.com/mgmt/tm/ltm/pool/~dev~sharepoint-2010-bmr-443.app~sharepoint-2010-bmr-443_pool
+
+#The URL format is $F5Session.BaseURL + '/pool/~$($Partition)~$($iApp).app~$($Pool)". It looks like Get-VirtualServer and other functions may have a similar problem.

--- a/F5-LTM/Public/Get-VirtualServer.ps1
+++ b/F5-LTM/Public/Get-VirtualServer.ps1
@@ -11,6 +11,10 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
+        [Alias('App')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
@@ -22,7 +26,7 @@
     }
     process {
         foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
             if ($JSON.items -or $JSON.name) {
                 Invoke-NullCoalescing {$JSON.items} {$JSON} |

--- a/F5-LTM/Public/Get-VirtualServer.ps1
+++ b/F5-LTM/Public/Get-VirtualServer.ps1
@@ -11,7 +11,7 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
-        [Alias('App')]
+        [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 

--- a/F5-LTM/Public/Get-iRule.ps1
+++ b/F5-LTM/Public/Get-iRule.ps1
@@ -13,6 +13,10 @@
         [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
+        [Alias('iApp')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
@@ -24,7 +28,7 @@
     }
     process {
         foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'rule/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'rule/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
             Invoke-NullCoalescing {$JSON.items} {$JSON} |
                 Add-ObjectDetail -TypeName 'PoshLTM.iRule'

--- a/F5-LTM/Public/Test-Pool.ps1
+++ b/F5-LTM/Public/Test-Pool.ps1
@@ -14,6 +14,10 @@
         [Parameter(Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name,
 
+        [Alias('App')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
@@ -25,7 +29,7 @@
     }
     process {
         foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
         }
     }

--- a/F5-LTM/Public/Test-Pool.ps1
+++ b/F5-LTM/Public/Test-Pool.ps1
@@ -14,7 +14,7 @@
         [Parameter(Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name,
 
-        [Alias('App')]
+        [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 

--- a/F5-LTM/Public/Test-VirtualServer.ps1
+++ b/F5-LTM/Public/Test-VirtualServer.ps1
@@ -14,7 +14,7 @@
         [Parameter(Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name,
 
-        [Alias('App')]
+        [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 

--- a/F5-LTM/Public/Test-VirtualServer.ps1
+++ b/F5-LTM/Public/Test-VirtualServer.ps1
@@ -14,6 +14,10 @@
         [Parameter(Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name,
 
+        [Alias('App')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Application,
+
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
@@ -25,7 +29,7 @@
     }
     process {
         foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
         }
     }


### PR DESCRIPTION
I would very much appreciate someone else confirming that these changes don't break anything for them before this gets merged.

To support referencing iApps, I updated the Get-ItemPath function to take an optional parameter $Application. Functions that reference Get-ItemPath, but do not include $Application, should remain unchanged. 

I also added the $Application parameter to the following functions:
- Get-Pool
- Get-VirtualServer
- Enable-VirtualServer
- Disable-VirtualServer
- Test-Pool
- Test-VirtualServer

I imagine that there are other functions that could use this parameter, but I am not sure about any others at this time. For example, Get-iRule references Get-ItemPath, but I have never seen an iRule created inside an iApp.

Here are some examples using $Application:
```
Get-Pool -F5Session $F5Session -Name sharepoint-2010-bmr-443_pool -Application sharepoint-2010-bmr-443 -Partition dev

Get-VirtualServer -F5Session $F5Session -Name sharepoint-2010-bmr-443_http_virtual -Application sharepoint-2010-bmr-443 -Partition dev

Enable-VirtualServer -F5Session $F5Session -Name sharepoint-2010-bmr-443_http_virtual -Application sharepoint-2010-bmr-443 -Partition dev

Disable-VirtualServer -F5Session $F5Session -Name sharepoint-2010-bmr-443_http_virtual -Application sharepoint-2010-bmr-443 -Partition dev

Test-Pool -F5Session $F5Session -Name sharepoint-2010-bmr-443_pool -Application sharepoint-2010-bmr-443 -Partition dev

Test-VirtualServer -F5Session $F5Session -Name sharepoint-2010-bmr-443_http_virtual -Application sharepoint-2010-bmr-443 -Partition dev
```

