### PR TITLE
ArgumentCompletion compatibility Ref #49

### DIFF
--- a/F5-LTM/Private/ArgumentCompletion.ps1
+++ b/F5-LTM/Private/ArgumentCompletion.ps1
@@ -167,68 +167,70 @@ function CompleteVirtualServerName {
         } 
     }
 }
+if (Get-Command Register-ArgumentCompleter -ErrorAction Ignore)
+{
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-PoolMember' -Module F5-LTM) `
+        -ParameterName Address `
+        -ScriptBlock $function:CompletePoolMemberAddress
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-PoolMember' -Module F5-LTM) `
-    -ParameterName Address `
-    -ScriptBlock $function:CompletePoolMemberAddress
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-PoolMember' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompletePoolMemberName
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-PoolMember' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompletePoolMemberName
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-PoolMonitor' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompletePoolMonitorName
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-PoolMonitor' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompletePoolMonitorName
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-HealthMonitor' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompleteMonitorName
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-HealthMonitor' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompleteMonitorName
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-HealthMonitor' -Module F5-LTM) `
+        -ParameterName Type `
+        -ScriptBlock $function:CompleteMonitorType
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-HealthMonitor' -Module F5-LTM) `
-    -ParameterName Type `
-    -ScriptBlock $function:CompleteMonitorType
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-Node' -Module F5-LTM) `
+        -ParameterName Address `
+        -ScriptBlock $function:CompleteNodeAddress
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-Node' -Module F5-LTM) `
-    -ParameterName Address `
-    -ScriptBlock $function:CompleteNodeAddress
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-Node' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompleteNodeName
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-Node' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompleteNodeName
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-Pool' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompletePoolName
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-Pool' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompletePoolName
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*' -Module F5-LTM) `
+        -ParameterName Partition `
+        -ScriptBlock $function:CompletePartition
+        
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command 'Get-Partition' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompletePartition
+        
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-Pool*' -Module F5-LTM) `
+        -ParameterName PoolName `
+        -ScriptBlock $function:CompletePoolName
+        
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command 'Get-iRule' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompleteRuleName
 
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*' -Module F5-LTM) `
-    -ParameterName Partition `
-    -ScriptBlock $function:CompletePartition
-    
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command 'Get-Partition' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompletePartition
-    
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-Pool*' -Module F5-LTM) `
-    -ParameterName PoolName `
-    -ScriptBlock $function:CompletePoolName
-    
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command 'Get-iRule' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompleteRuleName
-
-Register-ArgumentCompleter `
-    -CommandName @(Get-Command '*-VirtualServer' -Module F5-LTM) `
-    -ParameterName Name `
-    -ScriptBlock $function:CompleteVirtualServerName
+    Register-ArgumentCompleter `
+        -CommandName @(Get-Command '*-VirtualServer' -Module F5-LTM) `
+        -ParameterName Name `
+        -ScriptBlock $function:CompleteVirtualServerName
+}


### PR DESCRIPTION
Potentially fixes #49 

Conditionally Register-ArgumentCompletion functions.  As implemented, end users have the following options:
- Use PowerShell v5+
- Use PowerShell v3+ and Install-Module [TabExpansionPlusPlus](https://github.com/lzybkr/TabExpansionPlusPlus/blob/master/README.md#import-your-argument-completer)
- Live without argument completion