### PR TITLE
Resolved part1 and part2. Also updated Get-PoolMember for issue 55.

### DIFF
--- a/F5-LTM/Public/Disable-VirtualServer.ps1
+++ b/F5-LTM/Public/Disable-VirtualServer.ps1
@@ -7,24 +7,40 @@
     param(
         $F5Session=$Script:F5Session,
 
+        [Alias('VirtualServer')]
+        [Parameter(Mandatory=$false,ParameterSetName='InputObject',ValueFromPipeline=$true)]
+        [PSObject[]]$InputObject,
+
         [Alias("VirtualServerName")]
-        [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory=$false,ParameterSetName='VirtualServerName',ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
         [Alias('iApp')]
-        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory=$false,ParameterSetName='VirtualServerName',ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 
-        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory=$false,ParameterSetName='VirtualServerName',ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
     process {
         $JSONBody = "{`"disabled`":true}"
-        
-        foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to disable VirtualServer $itemname." -AsBoolean
-            Get-VirtualServer -F5Session $F5Session -Name $Name -Application $Application -Partition $Partition
+        switch($PSCmdLet.ParameterSetName) {
+            InputObject {
+                if ($null -eq $InputObject) {
+                    $InputObject = Get-VirtualServer -F5Session $F5Session -Partition $Partition
+                }
+                foreach($vs in $InputObject) {
+                    $URI = $F5Session.GetLink($vs.selfLink)
+                    $FullPath = $vs.fullPath
+                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable VirtualServer $itemname." -AsBoolean
+                    Get-VirtualServer -F5Session $F5Session -Name $FullPath
+                }
+            }
+            VirtualServerName {
+                foreach ($itemname in $Name) {
+                    Get-VirtualServer -F5Session $F5Session -Name $Name -Application $Application -Partition $Partition | Disable-VirtualServer -F5session $F5Session
+                }
+            }
         }
     }
 }

--- a/F5-LTM/Public/Disable-VirtualServer.ps1
+++ b/F5-LTM/Public/Disable-VirtualServer.ps1
@@ -32,7 +32,7 @@
                 foreach($vs in $InputObject) {
                     $URI = $F5Session.GetLink($vs.selfLink)
                     $FullPath = $vs.fullPath
-                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable VirtualServer $itemname." -AsBoolean
+                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody
                     Get-VirtualServer -F5Session $F5Session -Name $FullPath
                 }
             }

--- a/F5-LTM/Public/Enable-VirtualServer.ps1
+++ b/F5-LTM/Public/Enable-VirtualServer.ps1
@@ -7,24 +7,40 @@
     param(
         $F5Session=$Script:F5Session,
 
+        [Alias('VirtualServer')]
+        [Parameter(Mandatory=$false,ParameterSetName='InputObject',ValueFromPipeline=$true)]
+        [PSObject[]]$InputObject,
+
         [Alias("VirtualServerName")]
-        [Parameter(Mandatory=$false,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory=$false,ParameterSetName='VirtualServerName',ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
         [string[]]$Name='',
 
         [Alias('iApp')]
-        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory=$false,ParameterSetName='VirtualServerName',ValueFromPipelineByPropertyName=$true)]
         [string]$Application,
 
-        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory=$false,ParameterSetName='VirtualServerName',ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
     )
     process {
         $JSONBody = "{`"enabled`":true}"
-        
-        foreach ($itemname in $Name) {
-            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable VirtualServer $itemname." -AsBoolean
-            Get-VirtualServer -F5Session $F5Session -Name $Name -Application $Application -Partition $Partition
+        switch($PSCmdLet.ParameterSetName) {
+            InputObject {
+                if ($null -eq $InputObject) {
+                    $InputObject = Get-VirtualServer -F5Session $F5Session -Partition $Partition
+                }
+                foreach($vs in $InputObject) {
+                    $URI = $F5Session.GetLink($vs.selfLink)
+                    $FullPath = $vs.fullPath
+                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable VirtualServer $itemname." -AsBoolean
+                    Get-VirtualServer -F5Session $F5Session -Name $FullPath
+                }
+            }
+            VirtualServerName {
+                foreach ($itemname in $Name) {
+                    Get-VirtualServer -F5Session $F5Session -Name $Name -Application $Application -Partition $Partition | Enable-VirtualServer -F5session $F5Session
+                }
+            }
         }
     }
 }

--- a/F5-LTM/Public/Enable-VirtualServer.ps1
+++ b/F5-LTM/Public/Enable-VirtualServer.ps1
@@ -32,7 +32,7 @@
                 foreach($vs in $InputObject) {
                     $URI = $F5Session.GetLink($vs.selfLink)
                     $FullPath = $vs.fullPath
-                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable VirtualServer $itemname." -AsBoolean
+                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody
                     Get-VirtualServer -F5Session $F5Session -Name $FullPath
                 }
             }

--- a/F5-LTM/Public/Get-HealthMonitor.ps1
+++ b/F5-LTM/Public/Get-HealthMonitor.ps1
@@ -40,8 +40,11 @@
                 $URI = $F5Session.BaseURL + 'monitor/{0}' -f ($typename,(Get-ItemPath -Name $itemname -Application $Application -Partition $Partition) -join '/')
                 $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorAction $TypeSearchErrorAction
                 if ($JSON.items -or $JSON.name) {
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                        Add-ObjectDetail -TypeName 'PoshLTM.HealthMonitor' -PropertyToAdd @{type=$typename}
+                    $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
+                    if(![string]::IsNullOrWhiteSpace($Application) -and ![string]::IsNullOrWhiteSpace($Partition)) {
+                        $items = $items | Where-Object {$_.fullPath -like "/$Partition/$Application.app/*"}
+                    }
+                    $items | Add-ObjectDetail -TypeName 'PoshLTM.HealthMonitor' -PropertyToAdd @{type=$typename}
                 }
             }
         }

--- a/F5-LTM/Public/Get-HealthMonitor.ps1
+++ b/F5-LTM/Public/Get-HealthMonitor.ps1
@@ -15,7 +15,7 @@
 
         [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
-        [string]$Application,
+        [string]$Application='',
 
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,

--- a/F5-LTM/Public/Get-Pool.ps1
+++ b/F5-LTM/Public/Get-Pool.ps1
@@ -31,14 +31,11 @@
             $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
             if ($JSON.items -or $JSON.name) {
+                $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
                 if(![string]::IsNullOrWhiteSpace($Application)) {
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                        Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"} | 
-                            Add-ObjectDetail -TypeName 'PoshLTM.Pool'
-                } else {
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                        Add-ObjectDetail -TypeName 'PoshLTM.Pool'
+                    $items = $items | Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"}
                 }
+                $items | Add-ObjectDetail -TypeName 'PoshLTM.Pool'
             }
         }
     }

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -36,14 +36,13 @@
         if ($Address -ne '*') {
             for ([int]$a=0; $a -lt $Address.Count; $a++) {
                 $ip = [IPAddress]::Any
-                if ([IpAddress]::TryParse($Address[$a],[ref]$ip)) {
+                if($Address[$a] -match "[\d\.]+%\d+") {
+                    # Do not alter $Address[$a] if in format of IP%Partition
+                } elseif ([IpAddress]::TryParse($Address[$a],[ref]$ip)) {
                     $Address[$a] = $ip.IpAddressToString
                 } else {
                     $Address = [string]([System.Net.Dns]::GetHostAddresses($Address).IPAddressToString)
-                    #If we don't get an IP address for the computer, try the value specified
-                    If ($ip) {
-                        $Address[$a] = $ip
-                    }
+                    $Address[$a] = $ip
                 }
             }
         }

--- a/F5-LTM/Public/Get-VirtualServer.ps1
+++ b/F5-LTM/Public/Get-VirtualServer.ps1
@@ -13,7 +13,7 @@
 
         [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
-        [string]$Application,
+        [string]$Application='',
 
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition
@@ -29,8 +29,14 @@
             $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
             if ($JSON.items -or $JSON.name) {
-                Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                    Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
+                if(![string]::IsNullOrWhiteSpace($Application)) {
+                    Invoke-NullCoalescing {$JSON.items} {$JSON} |
+                        Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"} | 
+                            Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
+                } else {
+                    Invoke-NullCoalescing {$JSON.items} {$JSON} |
+                        Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
+                }
             }
         }
     }

--- a/F5-LTM/Public/Get-VirtualServer.ps1
+++ b/F5-LTM/Public/Get-VirtualServer.ps1
@@ -29,14 +29,11 @@
             $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
             if ($JSON.items -or $JSON.name) {
+                $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
                 if(![string]::IsNullOrWhiteSpace($Application)) {
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                        Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"} | 
-                            Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
-                } else {
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                        Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
+                    $items = $items | Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"}
                 }
+                $items | Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
             }
         }
     }

--- a/F5-LTM/Public/Get-iRule.ps1
+++ b/F5-LTM/Public/Get-iRule.ps1
@@ -15,7 +15,7 @@
 
         [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
-        [string]$Application,
+        [string]$Application='',
 
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition

--- a/F5-LTM/Public/Get-iRule.ps1
+++ b/F5-LTM/Public/Get-iRule.ps1
@@ -30,8 +30,13 @@
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'rule/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
             $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
-            Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                Add-ObjectDetail -TypeName 'PoshLTM.iRule'
+            if ($JSON.items -or $JSON.name) {
+                $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
+                if(![string]::IsNullOrWhiteSpace($Application) -and ![string]::IsNullOrWhiteSpace($Partition)) {
+                    $items = $items | Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"}
+                }
+                $items | Add-ObjectDetail -TypeName 'PoshLTM.iRule'
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request is to resolve issue #54.

**Part 1:** The following functions now support the Application parameter:
- Get-Pool
- Get-VirtualServer
- Get-HealthMonitor
- Get-iRule

If Name is null and Partition/Application parameters are not, the above functions return items filtered on both Partition and Application. Previously, the above functions would instead return all items in the partition.

**Part 2:** Similarly, the following functions now support an Application parameter:
- Disable-VirtualServer
- Enable-VirtualServer

If Name is null and Partition/Application parameters are not, the above functions will filter on both Partition and Application to enable/disable all virtual servers that match. Previously, the above functions would do nothing. (Dis|En)able-VirtualServer are now similar to Enable-PoolMember in that they support an InputObject and call Get-VirtualServer to apply the filtering.

**Part 3:** Get-PoolMember can now handle Address in the format {IP}%{Partition}. This partially resolves issue #55.