### PR TITLE
Issue24

### DIFF
--- a/F5-LTM/Public/Add-PoolMember.ps1
+++ b/F5-LTM/Public/Add-PoolMember.ps1
@@ -82,7 +82,7 @@
                                 } # else the node will be created
                                 $JSONBody = $JSONBody | ConvertTo-Json
                                 $MembersLink = $F5session.GetLink($pool.membersReference.link)
-                                Invoke-RestMethodOverride -Method POST -Uri "$MembersLink" -Credential $F5session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add $Name to $($pool.name)." | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'
+                                Invoke-RestMethodOverride -Method POST -Uri "$MembersLink" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add $Name to $($pool.name)." | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'
 
                                 #After adding to the pool, make sure the member status is set as specified
                                 If ($Status -eq "Enabled"){

--- a/F5-LTM/Public/Add-PoolMonitor.ps1
+++ b/F5-LTM/Public/Add-PoolMonitor.ps1
@@ -33,7 +33,7 @@
                         monitor=(($($_.monitor -split ' and ') + $Name | Where-Object { $_ } | ForEach-Object { [Regex]::Match($_.Trim(), '[^/\s]*$').Value } | Select-Object -Unique) -join ' and ')
                     } | ConvertTo-Json
                     $URI = $F5Session.GetLink($InputObject.selfLink)
-                    Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json'
+                    Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json'
                 }
             }
             PoolName {

--- a/F5-LTM/Public/Add-iRuleToVirtualServer.ps1
+++ b/F5-LTM/Public/Add-iRuleToVirtualServer.ps1
@@ -59,7 +59,7 @@ Function Add-iRuleToVirtualServer {
 
                             $JSONBody = @{rules=$iRules} | ConvertTo-Json
 
-                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add the $iRuleFullName iRule to the $Name virtual server." -AsBoolean 
+                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to add the $iRuleFullName iRule to the $Name virtual server." -AsBoolean 
                         }
                     }
                 }

--- a/F5-LTM/Public/Disable-PoolMember.ps1
+++ b/F5-LTM/Public/Disable-PoolMember.ps1
@@ -50,7 +50,7 @@
                         $JSONBody = @{state=$AcceptNewConnections;session='user-disabled'} | ConvertTo-Json
                         foreach($member in $InputObject) {
                             $URI = $F5Session.GetLink($member.selfLink)
-                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to disable $Address in the $PoolName pool." -AsBoolean
+                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ErrorMessage "Failed to disable $Address in the $PoolName pool." -AsBoolean
                         }
                     }
                 }

--- a/F5-LTM/Public/Disable-VirtualServer.ps1
+++ b/F5-LTM/Public/Disable-VirtualServer.ps1
@@ -32,7 +32,7 @@
                 foreach($vs in $InputObject) {
                     $URI = $F5Session.GetLink($vs.selfLink)
                     $FullPath = $vs.fullPath
-                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody
+                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -WebSession $F5Session.WebSession -Body $JSONBody
                     Get-VirtualServer -F5Session $F5Session -Name $FullPath
                 }
             }

--- a/F5-LTM/Public/Enable-PoolMember.ps1
+++ b/F5-LTM/Public/Enable-PoolMember.ps1
@@ -37,7 +37,7 @@
                         $JSONBody = @{state='user-up';session='user-enabled'} | ConvertTo-Json
                         foreach($member in $InputObject) {
                             $URI = $F5Session.GetLink($member.selfLink)
-                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ErrorMessage "Failed to enable $Address in the $PoolName pool." -AsBoolean
+                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ErrorMessage "Failed to enable $Address in the $PoolName pool." -AsBoolean
                         }
                     }
                 }

--- a/F5-LTM/Public/Enable-VirtualServer.ps1
+++ b/F5-LTM/Public/Enable-VirtualServer.ps1
@@ -32,7 +32,7 @@
                 foreach($vs in $InputObject) {
                     $URI = $F5Session.GetLink($vs.selfLink)
                     $FullPath = $vs.fullPath
-                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -Credential $F5Session.Credential -Body $JSONBody
+                    $JSON = Invoke-RestMethodOverride -Method PATCH -Uri $URI -WebSession $F5Session.WebSession -Body $JSONBody
                     Get-VirtualServer -F5Session $F5Session -Name $FullPath
                 }
             }

--- a/F5-LTM/Public/Get-F5Status.ps1
+++ b/F5-LTM/Public/Get-F5Status.ps1
@@ -13,7 +13,7 @@
 
     $FailoverPage = $F5Session.BaseURL -replace "/ltm/", "/cm/failover-status"
 
-    $FailoverJSON = Invoke-RestMethodOverride -Method Get -Uri $FailoverPage -Credential $F5Session.Credential
+    $FailoverJSON = Invoke-RestMethodOverride -Method Get -Uri $FailoverPage -WebSession $F5Session.WebSession
 
     #This is where the failover status is indicated
     $FailoverJSON.entries.'https://localhost/mgmt/tm/cm/failover-status/0'.nestedStats.entries.status.description

--- a/F5-LTM/Public/Get-HealthMonitor.ps1
+++ b/F5-LTM/Public/Get-HealthMonitor.ps1
@@ -38,7 +38,7 @@
         foreach ($typename in $Type) {
             foreach ($itemname in $Name) {
                 $URI = $F5Session.BaseURL + 'monitor/{0}' -f ($typename,(Get-ItemPath -Name $itemname -Application $Application -Partition $Partition) -join '/')
-                $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -ErrorAction $TypeSearchErrorAction
+                $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession -ErrorAction $TypeSearchErrorAction
                 if ($JSON.items -or $JSON.name) {
                     $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
                     if(![string]::IsNullOrWhiteSpace($Application) -and ![string]::IsNullOrWhiteSpace($Partition)) {

--- a/F5-LTM/Public/Get-HealthMonitorType.ps1
+++ b/F5-LTM/Public/Get-HealthMonitorType.ps1
@@ -18,7 +18,7 @@
     process {
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'monitor/'
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession
             $JSON.items.reference | ForEach-Object { 
                 [Regex]::Match($_.Link,'(?<=/)[^/?]*(?=\?)').Value |
                     Where-Object { $_ -like $itemname }

--- a/F5-LTM/Public/Get-Node.ps1
+++ b/F5-LTM/Public/Get-Node.ps1
@@ -28,7 +28,7 @@
     process {
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession
             Invoke-NullCoalescing {$JSON.items} {$JSON} | 
                 Where-Object { $Address -eq '*' -or $Address -contains $_.address} |
                 Add-ObjectDetail -TypeName 'PoshLTM.Node'

--- a/F5-LTM/Public/Get-Partition.ps1
+++ b/F5-LTM/Public/Get-Partition.ps1
@@ -27,7 +27,7 @@
                 $itemname = "~$itemname"
             }
             $URI = ($F5Session.BaseURL -replace 'ltm/','sys/folder') + '/{0}?$select=name,subPath' -f $itemname
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession
             Invoke-NullCoalescing {$JSON.items} {$JSON} | 
                 Where-Object { $_.subPath -eq '/' -and ([string]::IsNullOrEmpty($Name) -or $Name -contains $_.name) } |
                     Select-Object -ExpandProperty name

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -53,7 +53,7 @@
                 }
                 foreach($pool in $InputObject) {
                     $MembersLink = $F5Session.GetLink($pool.membersReference.link)
-                    $JSON = Invoke-RestMethodOverride -Method Get -Uri $MembersLink -Credential $F5Session.Credential
+                    $JSON = Invoke-RestMethodOverride -Method Get -Uri $MembersLink -WebSession $F5Session.WebSession
                     Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address -eq '*' -and $Name -eq '*') -or $Address -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {

--- a/F5-LTM/Public/Get-PoolMemberStats.ps1
+++ b/F5-LTM/Public/Get-PoolMemberStats.ps1
@@ -46,7 +46,7 @@
                         }
                         "tm:ltm:pool:members:membersstate" {
                             $URI = $F5Session.GetLink(($item.selfLink -replace '\?','/stats?'))
-                            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
+                            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession
                             Invoke-NullCoalescing {$JSON.entries} {$JSON} #|
                                 # Add-ObjectDetail -TypeName 'PoshLTM.PoolMemberStats'
                                 # TODO: Establish a type for formatting and return more columns, and consider adding a GetStats() ScriptMethod to PoshLTM.PoolMember  

--- a/F5-LTM/Public/Get-VirtualServer.ps1
+++ b/F5-LTM/Public/Get-VirtualServer.ps1
@@ -25,9 +25,10 @@
         Write-Verbose "NB: Virtual server names are case-specific."
     }
     process {
-        foreach ($itemname in $Name) {
+		foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
+
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession 
             if ($JSON.items -or $JSON.name) {
                 $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
                 if(![string]::IsNullOrWhiteSpace($Application)) {

--- a/F5-LTM/Public/Get-iRule.ps1
+++ b/F5-LTM/Public/Get-iRule.ps1
@@ -29,7 +29,7 @@
     process {
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'rule/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
-            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential
+            $JSON = Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession
             if ($JSON.items -or $JSON.name) {
                 $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
                 if(![string]::IsNullOrWhiteSpace($Application) -and ![string]::IsNullOrWhiteSpace($Partition)) {

--- a/F5-LTM/Public/Invoke-RestMethodOverride.ps1
+++ b/F5-LTM/Public/Invoke-RestMethodOverride.ps1
@@ -28,14 +28,14 @@
 
         switch($PSCmdLet.ParameterSetName) {
             Credential {
-				$Result = Invoke-RestMethod -Method $Method -Uri $URI -Credential $Credential -Body $Body -Headers $Headers -ContentType $ContentType;
-			}
-			WebSession {
-				$Result = Invoke-RestMethod -Method $Method -Uri $URI -Body $Body -Headers $Headers -ContentType $ContentType -Websession $WebSession ;
-			}
-			Default {
-				Throw("Either a PSCredential object or a WebSession object must be passed to Invoke-RestMethodOverride");
-			}
+                $Result = Invoke-RestMethod -Method $Method -Uri $URI -Credential $Credential -Body $Body -Headers $Headers -ContentType $ContentType;
+            }
+            WebSession {
+                $Result = Invoke-RestMethod -Method $Method -Uri $URI -Websession $WebSession -Body $Body -Headers $Headers -ContentType $ContentType;
+            }
+            Default {
+                Throw("Either a PSCredential object or a WebSession object must be passed to Invoke-RestMethodOverride");
+            }
 		}
 		
 		[SSLValidator]::RestoreValidation()

--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -12,17 +12,36 @@
     param(
         [Parameter(Mandatory=$true)][string]$LTMName,
         [Parameter(Mandatory=$true)][System.Management.Automation.PSCredential]$LTMCredentials,
+        [Parameter(Mandatory=$false)]$LoginReference,
         [switch]$Default,
         [switch]$PassThrough
     )
 
     $BaseURL = "https://$LTMName/mgmt/tm/ltm/"
-    
-    
-    $newSession = [pscustomobject]@{Name = $LTMName; BaseURL = $BaseURL; Credential = $LTMCredentials} | Add-Member -Name GetLink -MemberType ScriptMethod {
-         param($Link)
-         $Link -replace 'localhost', $this.Name    
-    } -PassThru 
+    $AuthURL = "https://$LTMName/mgmt/shared/authn/login";
+
+    $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+    if ($LoginReference) {
+
+		$JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password} | ConvertTo-Json
+
+		$Result = Invoke-RestMethodOverride -Method POST -Uri $AuthURL -Body $JSONBody -Credential $LTMCredentials -ContentType 'application/json'
+		$Token = $Result.token.token
+        $session.Headers.Add('X-F5-Auth-Token', $Token)
+
+    } else {
+        $session.Credentials = $LTMCredentials
+    }
+
+	$newSession = [pscustomobject]@{
+		Name = $LTMName; 
+		BaseURL = $BaseURL; 
+		WebSession = $session 
+		} | Add-Member -Name GetLink -MemberType ScriptMethod {
+		 param($Link)
+		 $Link -replace 'localhost', $this.Name    
+	} -PassThru 
+
 
     #If the Default switch is set, and/or if no script-scoped F5Session exists, then set the script-scoped F5Session
     If ($Default -or !($Script:F5Session)){

--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -21,7 +21,7 @@
 
     $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-	$JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password} | ConvertTo-Json
+	$JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password; loginProviderName='tmos'} | ConvertTo-Json
 
 	$Result = Invoke-RestMethodOverride -Method POST -Uri $AuthURL -Body $JSONBody -Credential $LTMCredentials -ContentType 'application/json'
 	$Token = $Result.token.token

--- a/F5-LTM/Public/New-HealthMonitor.ps1
+++ b/F5-LTM/Public/New-HealthMonitor.ps1
@@ -51,7 +51,7 @@
                 #Start building the JSON for the action
                 $JSONBody = @{name=$newitem.Name;partition=$newitem.Partition;recv=$Receive;send=$Send;interval=$Interval;timeout=$Timeout} | 
                     ConvertTo-Json
-                $newmonitor = Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to create the /$Type$($newitem.FullPath) health monitor."
+                $newmonitor = Invoke-RestMethodOverride -Method POST -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to create the /$Type$($newitem.FullPath) health monitor."
                 if ($Passthru) {
                     Get-HealthMonitor -F5Session $F5Session -Name $newmonitor.name -Partition $newmonitor.partition -Type $Type
                 }

--- a/F5-LTM/Public/New-Node.ps1
+++ b/F5-LTM/Public/New-Node.ps1
@@ -43,7 +43,7 @@
                 #Start building the JSON for the action
                 $JSONBody = @{address=$Address[$a];name=$newitem.Name;partition=$newitem.Partition;description=$Description[$a]} | ConvertTo-Json
 
-                Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' |
+                Invoke-RestMethodOverride -Method POST -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' |
                     Out-Null
                 if ($Passthru) {
                     Get-Node -F5Session $F5Session -Name $newitem.Name -Partition $newitem.Partition

--- a/F5-LTM/Public/New-Pool.ps1
+++ b/F5-LTM/Public/New-Pool.ps1
@@ -42,7 +42,7 @@
                 #Start building the JSON for the action
                 $JSONBody = @{name=$newitem.Name;partition=$newitem.Partition;members=@()} | ConvertTo-Json
 
-                Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage ("Failed to create the $($newitem.FullPath) pool.") -AsBoolean
+                Invoke-RestMethodOverride -Method POST -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -ErrorMessage ("Failed to create the $($newitem.FullPath) pool.") -AsBoolean
                 ForEach ($MemberDefinition in $MemberDefinitionList){
                     $Address,$PortNumber = $MemberDefinition -split ','
                     Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -Address $Address -PortNumber $PortNumber -Status Enabled

--- a/F5-LTM/Public/New-VirtualServer.ps1
+++ b/F5-LTM/Public/New-VirtualServer.ps1
@@ -13,6 +13,7 @@
         [Parameter(Mandatory=$false)]$Description=$null,
         [Parameter(Mandatory=$true)]$DestinationIP,
         [Parameter(Mandatory=$true)]$DestinationPort,
+	[Parameter(Mandatory=$false)][string[]]$Vlans,
         [Parameter(Mandatory=$false)]$Source='0.0.0.0/0',
         [Parameter(Mandatory=$false)]$DefaultPool=$null,
         [Parameter(Mandatory=$false)][string[]]$ProfileNames=$null,
@@ -37,7 +38,7 @@
 
         #Start building the JSON for the action
         $Destination = $DestinationIP + ":" + $DestinationPort
-        $JSONBody = @{kind=$Kind;name=$newitem.Name;description=$Description;partition=$newitem.Partition;destination=$Destination;source=$Source;pool=$DefaultPool;ipProtocol=$ipProtocol;mask=$Mask;connectionLimit=$ConnectionLimit}
+        $JSONBody = @{kind=$Kind;name=$newitem.Name;description=$Description;partition=$newitem.Partition;destination=$Destination;vlans=$Vlans;source=$Source;pool=$DefaultPool;ipProtocol=$ipProtocol;mask=$Mask;connectionLimit=$ConnectionLimit}
 
         #Build array of profile items
         #JN: What happens if a non-existent profile is passed in?

--- a/F5-LTM/Public/New-VirtualServer.ps1
+++ b/F5-LTM/Public/New-VirtualServer.ps1
@@ -51,6 +51,6 @@
 
         Write-Verbose $JSONBody
 
-        Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to create the $($newitem.FullPath) virtual server."
+        Invoke-RestMethodOverride -Method POST -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to create the $($newitem.FullPath) virtual server."
     }
 }

--- a/F5-LTM/Public/New-VirtualServer.ps1
+++ b/F5-LTM/Public/New-VirtualServer.ps1
@@ -13,7 +13,7 @@
         [Parameter(Mandatory=$false)]$Description=$null,
         [Parameter(Mandatory=$true)]$DestinationIP,
         [Parameter(Mandatory=$true)]$DestinationPort,
-	[Parameter(Mandatory=$false)][string[]]$Vlans,
+	    [Parameter(Mandatory=$false)][string[]]$Vlans,
         [Parameter(Mandatory=$false)]$Source='0.0.0.0/0',
         [Parameter(Mandatory=$false)]$DefaultPool=$null,
         [Parameter(Mandatory=$false)][string[]]$ProfileNames=$null,

--- a/F5-LTM/Public/Remove-HealthMonitor.ps1
+++ b/F5-LTM/Public/Remove-HealthMonitor.ps1
@@ -40,7 +40,7 @@
                 foreach($item in $InputObject) {
                     if ($pscmdlet.ShouldProcess($item.fullPath)){
                         $URI = $F5Session.GetLink($item.selfLink)
-                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -WebSession $F5Session.WebSession
                     }
                 }
             }

--- a/F5-LTM/Public/Remove-Node.ps1
+++ b/F5-LTM/Public/Remove-Node.ps1
@@ -42,7 +42,7 @@
                 foreach($item in $InputObject) {
                     if ($pscmdlet.ShouldProcess($item.fullPath)){
                         $URI = $F5Session.GetLink($item.selfLink)
-                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -WebSession $F5Session.WebSession
                     }
                 }
             }

--- a/F5-LTM/Public/Remove-Pool.ps1
+++ b/F5-LTM/Public/Remove-Pool.ps1
@@ -32,7 +32,7 @@
                 foreach($item in $InputObject) {
                     if ($pscmdlet.ShouldProcess($item.fullPath)){
                         $URI = $F5Session.GetLink($item.selfLink)
-                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -WebSession $F5Session.WebSession
                     }
                 }
             }

--- a/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-LTM/Public/Remove-PoolMember.ps1
@@ -47,7 +47,7 @@
                         "tm:ltm:pool:members:membersstate" {
                             if ($pscmdlet.ShouldProcess($item.GetFullName())) {
                                 $URI = $F5Session.GetLink($item.selfLink)
-                                Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential
+                                Invoke-RestMethodOverride -Method DELETE -Uri $URI -WebSession $F5Session.WebSession
                             }
                         }
                     }

--- a/F5-LTM/Public/Remove-PoolMonitor.ps1
+++ b/F5-LTM/Public/Remove-PoolMonitor.ps1
@@ -35,7 +35,7 @@
                         $monitor = ($pool.monitor -split ' and ' | Where-Object { $Name -notcontains $_.Trim() }) -join ' and '
                         $JSONBody = @{monitor=$monitor} | ConvertTo-Json
                         $URI = $F5Session.GetLink($pool.selfLink)
-                        Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json'
+                        Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json'
                     }
                 }
             }

--- a/F5-LTM/Public/Remove-ProfileRamCache.ps1
+++ b/F5-LTM/Public/Remove-ProfileRamCache.ps1
@@ -16,6 +16,6 @@
 
     $ProfileURL = $F5Session.BaseURL +$ProfileName
 
-    Invoke-RestMethodOverride -Method DELETE -Uri "$ProfileURL" -Credential $F5Session.Credential -ErrorMessage "Failed to clear the ram cache for the $ProfileName profile." |
+    Invoke-RestMethodOverride -Method DELETE -Uri "$ProfileURL" -WebSession $F5Session.WebSession -ErrorMessage "Failed to clear the ram cache for the $ProfileName profile." |
         Out-Null
 }

--- a/F5-LTM/Public/Remove-VirtualServer.ps1
+++ b/F5-LTM/Public/Remove-VirtualServer.ps1
@@ -32,7 +32,7 @@
                 foreach($virtualserver in $InputObject) {
                     if ($pscmdlet.ShouldProcess($virtualserver.fullPath)){
                         $URI = $F5Session.GetLink($virtualserver.selfLink)
-                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -Credential $F5Session.Credential
+                        Invoke-RestMethodOverride -Method DELETE -Uri $URI -WebSession $F5Session.WebSession
                     }
                 }
             }

--- a/F5-LTM/Public/Remove-iRuleFromVirtualServer.ps1
+++ b/F5-LTM/Public/Remove-iRuleFromVirtualServer.ps1
@@ -52,7 +52,7 @@
 
                             $JSONBody = @{rules=$iRules} | ConvertTo-Json
 
-                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json'
+                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json'
                         }
                         Else {
                             Write-Warning "The $($VirtualServer.name) virtual server does not contain the $iRuleFullName iRule."

--- a/F5-LTM/Public/Set-PoolMemberDescription.ps1
+++ b/F5-LTM/Public/Set-PoolMemberDescription.ps1
@@ -40,7 +40,7 @@
                         foreach($member in $InputObject) {
                             $JSONBody = @{description=$Description} | ConvertTo-Json
                             $URI = $F5Session.GetLink($member.selfLink)
-                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to set the description on $ComputerName in the $PoolName pool to $Description." -AsBoolean
+                            Invoke-RestMethodOverride -Method PATCH -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to set the description on $ComputerName in the $PoolName pool to $Description." -AsBoolean
                         }
                     }
                 }

--- a/F5-LTM/Public/Set-iRule.ps1
+++ b/F5-LTM/Public/Set-iRule.ps1
@@ -1,0 +1,130 @@
+﻿Function Set-iRule 
+{
+    <#
+        .SYNOPSIS
+            Create or updates an iRule
+        .DESCRIPTION
+            Can create a new, and update an existing iRule.
+            Removes iRule from VirtualServers and adds them back again after uploading new iRule.
+            The command supports -whatif
+        .PARAMETER iRuleContent
+            The content of the iRule (as a string).
+            Alias: iRuleContent
+        .PARAMETER Partition
+            The partition on the F5 to put the iRule on. The full path will be /Partition/iRuleName.
+        .PARAMETER OverWrite
+            Overwrite the iRule already present on F5. It will:
+            - check if any VirtualServers have the iRule configured
+            - remove the iRule from those VirtualServers
+            - delete old and upload new iRule
+            - add the iRule back to the VirtualServers.
+        .EXAMPLE
+            Set-iRule -name 'NameThatMakesSense' -apiAnonymous $ObjectofStrings
+    #>
+    [cmdletbinding(SupportsShouldProcess = $True)]
+    param (
+        $F5Session = $Script:F5Session,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Alias('apiAnonymous')]
+        [Parameter(Mandatory)]
+        [string]$iRuleContent,
+        [string]$Partition = 'Common',
+        [switch]$OverWrite
+    )
+    
+    begin {
+        Test-F5Session -F5Session ($F5Session)
+
+        $URI = ($F5Session.BaseURL + 'rule')
+    }
+    
+    process {
+        $newitem = New-F5Item -Name $Name
+        
+        $kind = 'tm:ltm:rule:rulestate'
+        
+        $iRuleFullName = "/$Partition/$Name"
+            
+        $JSONBody = @{
+            kind         = $kind
+            name         = $newitem.Name
+            fullPath     = $newitem.Name
+            apiAnonymous = $iRuleContent
+        }
+                
+        $JSONBody = $JSONBody | ConvertTo-Json -Compress
+        
+        #Caused by a bug in ConvertTo-Json https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/11088243-provide-option-to-not-encode-html-special-characte
+        #'<', '>' and ''' are replaced by ConvertTo-Json to \\u003c, \\u003e and \\u0027. The F5 API doesn't understand this. Change them back.
+        $ReplaceChars = @{
+            '\\u003c' = '<'
+            '\\u003e' = '>'
+            '\\u0027' = "'"
+        }
+
+        foreach ($Char in $ReplaceChars.GetEnumerator()) 
+        {
+            $JSONBody = $JSONBody -replace $Char.Key, $Char.Value
+        }
+        
+        $iRuleonServer = Get-iRule -Name $newitem.Name -ErrorAction SilentlyContinue
+        
+        if ($iRuleonServer)
+        {
+            if ($iRuleonServer.apiAnonymous -eq $iRuleContent)
+            {
+                Write-Verbose -Message 'iRule on server is already in place'
+                $iRulesDifferent = $false
+                $true
+            }
+            
+            else
+            {
+                $iRulesDifferent = $True
+
+                if ($OverWrite)
+                {
+                    Write-Verbose -Message 'iRule on server is different from current version, and OverWrite flag was set. Removing the iRule from VirtualServer and adding the new one.'
+                    
+                    $VirtualServers = Get-VirtualServer | Where-Object -Property rules -EQ -Value $iRuleFullName
+                    
+                    foreach ($Virtualserver in $VirtualServers)
+                    {
+                        if ($pscmdlet.ShouldProcess($Virtualserver.Name, "Remove iRule $Name from VirtualServer"))
+                        {
+                            $Null = $Virtualserver | Remove-iRuleFromVirtualServer -iRuleName $Name
+                        }
+                    }
+                    
+                    if ($pscmdlet.ShouldProcess($F5Session.Name, "Deleting iRule $Name"))
+                    {
+                        $URIOldiRule = $F5Session.GetLink($iRuleonServer.selfLink)
+                        Invoke-RestMethodOverride -Method DELETE -URI $URIOldiRule -WebSession $F5Session.WebSession
+                    }
+                }
+                
+                else
+                {
+                    Write-Warning -Message 'iRule on server is different from current version, set OverWrite flag to overwrite current iRule.'
+                }
+            }
+        }
+        
+        if ( (-not $iRuleonServer) -or ($iRuleonServer -and $iRulesDifferent -and $OverWrite) )
+        {
+            if ($pscmdlet.ShouldProcess($F5Session.Name, "Uploading iRule $Name"))
+            {
+                Invoke-RestMethodOverride -Method POST -URI "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -AsBoolean
+            }
+            
+            foreach ($Virtualserver in $VirtualServers)
+            {
+                if ($pscmdlet.ShouldProcess($Virtualserver.Name, "Add iRule $Name"))
+                {
+                    $Null = Get-VirtualServer -name $Virtualserver.Name | Add-iRuleToVirtualServer -iRuleName $Name
+                }
+            }
+        }
+    }
+}

--- a/F5-LTM/Public/Sync-DeviceToGroup.ps1
+++ b/F5-LTM/Public/Sync-DeviceToGroup.ps1
@@ -17,5 +17,5 @@
     $JSONBody = @{command='run';utilCmdArgs="config-sync to-group $GroupName"}
     $JSONBody = $JSONBody | ConvertTo-Json
 
-    Invoke-RestMethodOverride -Method POST -Uri "$URI" -Credential $F5Session.Credential -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to sync the device to the $GroupName group" -AsBoolean
+    Invoke-RestMethodOverride -Method POST -Uri "$URI" -WebSession $F5Session.WebSession -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to sync the device to the $GroupName group" -AsBoolean
 }

--- a/F5-LTM/Public/Test-F5Session.ps1
+++ b/F5-LTM/Public/Test-F5Session.ps1
@@ -7,9 +7,14 @@ Function Test-F5Session {
     param (
         [Parameter(Mandatory=$true)][AllowNull()]$F5Session
     )
-    #Validate F5Session 
+    #Verify the format of the BaseURL property and the existence of a WebRequestSession object.
     If ($($F5Session.BaseURL) -ne ("https://$($F5Session.Name)/mgmt/tm/ltm/") -or ($F5Session.WebSession.GetType().name -ne 'WebRequestSession')) { 
         Write-Error 'You must either create an F5 Session with script scope (by calling New-F5Session) or pass an F5 session to this function.' 
     }
+
+    #Make a basic call using the F5 session and see if it passes
+    $FailoverPage = $F5Session.BaseURL -replace "/ltm/", "/cm/failover-status"
+    $FailoverJSON = Invoke-RestMethodOverride -Method Get -Uri $FailoverPage -WebSession $F5Session.WebSession
+
 }
 

--- a/F5-LTM/Public/Test-F5Session.ps1
+++ b/F5-LTM/Public/Test-F5Session.ps1
@@ -8,7 +8,8 @@ Function Test-F5Session {
         [Parameter(Mandatory=$true)][AllowNull()]$F5Session
     )
     #Validate F5Session 
-    If ($($F5Session.BaseURL) -ne ("https://$($F5Session.Name)/mgmt/tm/ltm/") -or ($F5Session.Credential.GetType().name -ne 'PSCredential')) { 
+    If ($($F5Session.BaseURL) -ne ("https://$($F5Session.Name)/mgmt/tm/ltm/") -or ($F5Session.WebSession.GetType().name -ne 'WebRequestSession')) { 
         Write-Error 'You must either create an F5 Session with script scope (by calling New-F5Session) or pass an F5 session to this function.' 
     }
 }
+

--- a/F5-LTM/Public/Test-Functionality.ps1
+++ b/F5-LTM/Public/Test-Functionality.ps1
@@ -22,7 +22,7 @@
     Get-F5Status -F5Session $F5Session
 
     Write-Host "`r`n* Get a list of all pools" -ForegroundColor $TestNotesColor
-    $pools = Get-PoolList -F5Session $F5Session
+    $pools = Get-Pool -F5Session $F5Session | Select-Object -ExpandProperty fullPath
     $pools
 
     Write-Host ("`r`n* Test whether the first pool in the list - " + $pools[0] + " - exists") -ForegroundColor $TestNotesColor
@@ -32,10 +32,10 @@
     Get-Pool -F5Session $F5Session -PoolName $pools[0]
 
     Write-Host ("`r`n* Get members of the pool '" + $pools[0] + "'") -ForegroundColor $TestNotesColor
-    Get-PoolMemberCollection -F5Session $F5Session -PoolName $pools[0]
+    Get-PoolMember -F5Session $F5Session -PoolName $pools[0]
 
     Write-Host ("`r`n* Get the status of all members in the " + $pools[0] + " pool") -ForegroundColor $TestNotesColor
-    Get-PoolMemberCollectionStatus -F5Session $F5Session -PoolName $pools[0]
+    Get-PoolMember -F5Session $F5Session -PoolName $pools[0] | Select-Object -Property name,session,state
 
     Write-Host "`r`n* Create a new pool named '$TestPool'" -ForegroundColor $TestNotesColor
     New-Pool -F5Session $F5Session -PoolName $TestPool 
@@ -47,36 +47,38 @@
     Get-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
 
     Write-Host "`r`n* Get the IP address for the new pool member" -ForegroundColor $TestNotesColor
-    Get-PoolMemberIP -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
+    Get-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool | Select-Object -ExpandProperty address
 
     Write-Host "`r`n* Get all pools of which this pool member is a member" -ForegroundColor $TestNotesColor
     Get-PoolsForMember -F5Session $F5Session -ComputerName $PoolMember
 
     Write-Host "`r`n* Get the number of current connections for this pool member" -ForegroundColor $TestNotesColor
-    Get-CurrentConnectionCount -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
+    Get-PoolMemberStats -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool | Select-Object -ExpandProperty 'serverside.curConns'
 
     Write-Host "`r`n* Disable the new pool member" -ForegroundColor $TestNotesColor
     Disable-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
 
     Write-Host "`r`n* Get the status of the new pool member" -ForegroundColor $TestNotesColor
-    $PoolMemberStatus = Get-PoolMemberStatus -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
+    $PoolMemberStatus = Get-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool | Select-Object -Property name,session,state
     $PoolMemberStatus
 
     Write-Host "`r`n* Set the pool member description to 'My new pool' and retrieve it" -ForegroundColor $TestNotesColor
     Write-Host "Old description:"
-    Get-PoolMemberDescription -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
+    #NB: If there is not description for the pool member, no Description propery is returned.
+    Get-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool | Select-Object -ExpandProperty Description -ErrorAction SilentlyContinue
+
     Set-PoolMemberDescription -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool -Description 'My new pool' | out-null
     Write-Host "New description:"
-    Get-PoolMemberDescription -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
-
+    Get-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool | Select-Object -ExpandProperty Description
+    
     Write-Host "`r`n* Enable the new pool member" -ForegroundColor $TestNotesColor
     Enable-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
 
     Write-Host "`r`n* Remove the new pool member from the pool" -ForegroundColor $TestNotesColor
-    Remove-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PortNumber 80 -PoolName $TestPool
+    Remove-PoolMember -F5Session $F5Session -ComputerName $PoolMember -PoolName $TestPool
 
     Write-Host "`r`n* Get a list of all virtual servers" -ForegroundColor $TestNotesColor
-    $virtualServers = Get-VirtualServerList -F5Session $F5Session
+    $virtualServers = Get-VirtualServer -F5Session $F5Session | Select-Object -ExpandProperty fullPath
     $virtualServers
 
     Write-Host ("`r`n* Test whether the first virtual server in the list - " +  $virtualServers[0] + " - exists") -ForegroundColor $TestNotesColor
@@ -89,7 +91,7 @@
     New-VirtualServer -F5Session $F5Session -VirtualServerName $TestVirtualServer -Description 'description' -DestinationIP $TestVirtualServerIP -DestinationPort '80' -DefaultPool $TestPool -IPProtocol 'tcp' -ProfileNames 'http'
 
     Write-Host ("`r`n* Retrieve all iRules on the F5 LTM device.") -ForegroundColor $TestNotesColor
-    $iRules = Get-iRuleCollection -F5Session $F5Session
+    $iRules = Get-iRule -F5Session $F5Session
     Write-Output ("- This can be a large collection. The first entry found is:")
     Write-Output $iRules[0]
 
@@ -97,7 +99,7 @@
     Add-iRuleToVirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer -iRuleName $($iRules[0].fullPath)
 
     Write-Host "`r`n* Get all iRules assigned to '$TestVirtualServer'" -ForegroundColor $TestNotesColor
-    Get-VirtualServeriRuleCollection -F5Session $F5Session -VirtualServer $TestVirtualServer 
+    Get-VirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer | Select-Object -ExpandProperty rules
 
     Write-Host ("`r`n* Remove the '" + $iRules[0].name + "' iRule from the new virtual server '$TestVirtualServer'") -ForegroundColor $TestNotesColor
     Remove-iRuleFromVirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer -iRuleName $iRules[0].name

--- a/F5-LTM/Public/Test-Functionality.ps1
+++ b/F5-LTM/Public/Test-Functionality.ps1
@@ -25,17 +25,25 @@
     $pools = Get-Pool -F5Session $F5Session | Select-Object -ExpandProperty fullPath
     $pools
 
-    Write-Host ("`r`n* Test whether the first pool in the list - " + $pools[0] + " - exists") -ForegroundColor $TestNotesColor
-    Test-Pool -F5Session $F5Session -PoolName $pools[0]
+    #Get the first pool. If there is only one, don't treat it as an array
+    If ($pools -is [system.array]){
+        $FirstPool = $pools[0];
+    }
+    Else {
+        $FirstPool = $pools
+    }
 
-    Write-Host ("`r`n* Get the pool " + $pools[0]) -ForegroundColor $TestNotesColor
-    Get-Pool -F5Session $F5Session -PoolName $pools[0]
+    Write-Host ("`r`n* Test whether the first pool in the list - " + $FirstPool + " - exists") -ForegroundColor $TestNotesColor
+    Test-Pool -F5Session $F5Session -PoolName $FirstPool
 
-    Write-Host ("`r`n* Get members of the pool '" + $pools[0] + "'") -ForegroundColor $TestNotesColor
-    Get-PoolMember -F5Session $F5Session -PoolName $pools[0]
+    Write-Host ("`r`n* Get the pool " + $FirstPool) -ForegroundColor $TestNotesColor
+    Get-Pool -F5Session $F5Session -PoolName $FirstPool
 
-    Write-Host ("`r`n* Get the status of all members in the " + $pools[0] + " pool") -ForegroundColor $TestNotesColor
-    Get-PoolMember -F5Session $F5Session -PoolName $pools[0] | Select-Object -Property name,session,state
+    Write-Host ("`r`n* Get members of the pool '" + $FirstPool + "'") -ForegroundColor $TestNotesColor
+    Get-PoolMember -F5Session $F5Session -PoolName $FirstPool
+
+    Write-Host ("`r`n* Get the status of all members in the " + $FirstPool + " pool") -ForegroundColor $TestNotesColor
+    Get-PoolMember -F5Session $F5Session -PoolName $FirstPool | Select-Object -Property name,session,state
 
     Write-Host "`r`n* Create a new pool named '$TestPool'" -ForegroundColor $TestNotesColor
     New-Pool -F5Session $F5Session -PoolName $TestPool 
@@ -95,14 +103,14 @@
     Write-Output ("- This can be a large collection. The first entry found is:")
     Write-Output $iRules[0]
 
-    Write-Host ("`r`n* Add the iRule '" + $iRules[0].fullPath + "' to the new virtual server '$TestVirtualServer'") -ForegroundColor $TestNotesColor
-    Add-iRuleToVirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer -iRuleName $($iRules[0].fullPath)
+    Write-Host ("`r`n* Add the iRule '_sys_https_redirect' to the new virtual server '$TestVirtualServer'") -ForegroundColor $TestNotesColor
+    Add-iRuleToVirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer -iRuleName '_sys_https_redirect'
 
     Write-Host "`r`n* Get all iRules assigned to '$TestVirtualServer'" -ForegroundColor $TestNotesColor
     Get-VirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer | Select-Object -ExpandProperty rules
 
-    Write-Host ("`r`n* Remove the '" + $iRules[0].name + "' iRule from the new virtual server '$TestVirtualServer'") -ForegroundColor $TestNotesColor
-    Remove-iRuleFromVirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer -iRuleName $iRules[0].name
+    Write-Host ("`r`n* Remove the '_sys_https_redirect' iRule from the new virtual server '$TestVirtualServer'") -ForegroundColor $TestNotesColor
+    Remove-iRuleFromVirtualServer -F5Session $F5Session -VirtualServer $TestVirtualServer -iRuleName '_sys_https_redirect'
 
     Write-Host "`r`n* Remove the new virtual server '$TestVirtualServer'" -ForegroundColor $TestNotesColor
     Write-Host "(This will raise a confirmation prompt unless -confirm is set to false)" -ForegroundColor $TestNotesColor

--- a/F5-LTM/Public/Test-HealthMonitor.ps1
+++ b/F5-LTM/Public/Test-HealthMonitor.ps1
@@ -29,7 +29,7 @@
     process {
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'monitor/{0}/{1}' -f $Type,(Get-ItemPath -Name $itemname -Partition $Partition)
-            Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
+            Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession -AsBoolean
         }
     }
 }

--- a/F5-LTM/Public/Test-Node.ps1
+++ b/F5-LTM/Public/Test-Node.ps1
@@ -42,7 +42,7 @@
             Name {
                 foreach ($itemname in $Name) {
                     $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
-                    Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
+                    Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession -AsBoolean
                 }
             }
         }

--- a/F5-LTM/Public/Test-Pool.ps1
+++ b/F5-LTM/Public/Test-Pool.ps1
@@ -30,7 +30,7 @@
     process {
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'pool/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
-            Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
+            Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession -AsBoolean
         }
     }
 }

--- a/F5-LTM/Public/Test-VirtualServer.ps1
+++ b/F5-LTM/Public/Test-VirtualServer.ps1
@@ -30,7 +30,7 @@
     process {
         foreach ($itemname in $Name) {
             $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $itemname -Application $Application -Partition $Partition)
-            Invoke-RestMethodOverride -Method Get -Uri $URI -Credential $F5Session.Credential -AsBoolean
+            Invoke-RestMethodOverride -Method Get -Uri $URI -WebSession $F5Session.WebSession -AsBoolean
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ skip_commits:
   # Skip on updates to the readme. [skip ci] or [ci skip] anywhere in commit message will also prevent a ci build 
   message: /update readme.*/
   
-version: 1.3.{build}
+version: 1.4.{build}
 
 install:
   # Force bootstrap of the Nuget PackageManagement Provider; Reference: http://www.powershellgallery.com/GettingStarted?section=Get%20Started


### PR DESCRIPTION
This pull requests updates the authentication mechanism from basic to token-based and uses WebSessions instead of basic Credential authentication. Local authentication with tokens is supported in v. 11.6 and higher. For remote authentication, token-based auth is required for the iControlREST API and version 12.0 or higher of the LTM is needed to do that.

This also updates the Test-Functionality function to not use deprecated functions. 

Two thing to notes:
1) it appears the call to get the current connection count of a pool member needs to change as the JSON data returned in 12.1 is different that 11.6. This will be addressed in a separate issue.
2) the diff on this pull request was showing sanderma's changes as new additions, even though they had already been merged into the master branch.


