### PR TITLE
Issue #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # POSH-LTM-Rest
 This PowerShell module uses the F5 LTM REST API to manipulate and query pools, pool members, virtual servers and iRules.
-It is built to work with version 11.6 and higher
+It is built to work with the following BIG-IP versions:
+11.5.1 Build 8.0.175 Hotfix 8 and later
+11.6.0 Build 5.0.429 Hotfix 4 and later
+All versions of 12.x
 
 It requires PowerShell v3 or higher.
 


### PR DESCRIPTION
Until the Test-Functionality script is replaced by the Pester tests, it can be used to test basic functionality in the PS module. Hence, it shouldn't be referencing deprecated functions. Also, adding the first iRule found to the test virtual server doesn't always succeed, so now we add the _sys_https_redirect iRule, which is accepted by this virtual server.

Also, the ReadMe has been updated to claim support for the following BIG-IP versions:
11.5.1 Build 8.0.175 Hotfix 8 and later
11.6.0 Build 5.0.429 Hotfix 4 and later
All versions of 12.x