### PR TITLE
Changing Get-Partition and CompletePartition functions

### DIFF
--- a/F5-LTM/Private/ArgumentCompletion.ps1
+++ b/F5-LTM/Private/ArgumentCompletion.ps1
@@ -60,7 +60,7 @@ function CompleteNodeName {
         } 
     }
 }
-function CompletePartition {
+function CompleteBIGIPPartition {
     param($commandName,
         $parameterName,
         $wordToComplete,
@@ -68,7 +68,7 @@ function CompletePartition {
         $fakeBoundParameters)
     $Session = Get-CompleteSession $fakeBoundParameters.F5Session    
     if ($Session) {
-        Get-Partition -F5Session $Session | Where-Object { $_ -like "$wordToComplete*" }
+        Get-BIGIPPartition -F5Session $Session | Where-Object { $_ -like "$wordToComplete*" }
     }
 }
 function CompletePoolMemberAddress {
@@ -215,9 +215,9 @@ if (Get-Command Register-ArgumentCompleter -ErrorAction Ignore)
         -ScriptBlock $function:CompletePartition
         
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command 'Get-Partition' -Module F5-LTM) `
+        -CommandName @(Get-Command 'Get-BIGIPPartition' -Module F5-LTM) `
         -ParameterName Name `
-        -ScriptBlock $function:CompletePartition
+        -ScriptBlock $function:CompleteBIGIPPartition
         
     Register-ArgumentCompleter `
         -CommandName @(Get-Command '*-Pool*' -Module F5-LTM) `

--- a/F5-LTM/Public/Get-BIGIPPartition.ps1
+++ b/F5-LTM/Public/Get-BIGIPPartition.ps1
@@ -1,4 +1,4 @@
-﻿Function Get-Partition {
+﻿Function Get-BIGIPPartition {
 <#
 .SYNOPSIS
     Retrieve specified Partition(s)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The module contains the following functions.
    * Get-iRule
    * Get-iRuleCollection (deprecated; use __Get-iRule__)
    * Get-Node
-   * Get-Partition
+   * Get-BIGIPPartition
    * Get-Pool
    * Get-PoolList (deprecated; use __Get-Pool__)
    * Get-PoolMember


### PR DESCRIPTION
Renaming to Get-BIGIPPartition and CompleteBIGIPPartition, to avoid collision with Microsoft's Get-Partition storage cmdlet.

See Issue #69 