### PR TITLE
Changed New-F5Session to handle LTMs with external authorization. If …

### DIFF
--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -19,13 +19,12 @@
 
     $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-    $F5Version = Invoke-RestMethodOverride -Method Get -Uri "https://$LTMName/mgmt/tm/sys/version" -Credential $LTMCredentials -ContentType 'application/json'
-    if ([version]([Regex]::Match($F5Version.selfLink,'(\d\.?)+$').Value) -lt [version]11.6) {
-        $session.Credentials = $LTMCredentials
-    } else {
-        $AuthURL = "https://$LTMName/mgmt/shared/authn/login";
-        $JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password; loginProviderName='tmos'} | ConvertTo-Json
+    #First we attempt to get an auth token. We need an auth token to do anything, include getting the LTM version, for LTMs using external auth.
+    #If we fail to get an auth token, that means the version is prior to 11.6, so we fall back on basic auth
+    $AuthURL = "https://$LTMName/mgmt/shared/authn/login";
+    $JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password; loginProviderName='tmos'} | ConvertTo-Json
 
+    Try {
         $Result = Invoke-RestMethodOverride -Method POST -Uri $AuthURL -Body $JSONBody -Credential $LTMCredentials -ContentType 'application/json'
         $Token = $Result.token.token
         $session.Headers.Add('X-F5-Auth-Token', $Token)
@@ -36,6 +35,10 @@
         $ExpirationTime = $date + $ts
         $session.Headers.Add('Token-Expiration', $ExpirationTime)
     }
+    Catch {
+        Write-Verbose "The version must be prior to 11.6 since we failed to retrieve an auth token."
+        $session.Credentials = $LTMCredentials
+    }
 
     $newSession = [pscustomobject]@{
             Name = $LTMName
@@ -44,7 +47,7 @@
         } | Add-Member -Name GetLink -MemberType ScriptMethod {
                 param($Link)
                 $Link -replace 'localhost', $this.Name    
-            } -PassThru 
+    } -PassThru 
 
     #If the Default switch is set, and/or if no script-scoped F5Session exists, then set the script-scoped F5Session
     If ($Default -or !($Script:F5Session)){


### PR DESCRIPTION
…external auth is used, we can't check the version without first getting an auth token. If we have to get an auth token first, we do that in a Try-Catch and if we catch an exception and fail to get an auth token, we resort to basic authentication.