### PR TITLE
Joel74

### DIFF
--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -19,13 +19,12 @@
 
     $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-    $F5Version = Invoke-RestMethodOverride -Method Get -Uri "https://$LTMName/mgmt/tm/sys/version" -Credential $LTMCredentials -ContentType 'application/json'
-    if ([version]([Regex]::Match($F5Version.selfLink,'(\d\.?)+$').Value) -lt [version]11.6) {
-        $session.Credentials = $LTMCredentials
-    } else {
-        $AuthURL = "https://$LTMName/mgmt/shared/authn/login";
-        $JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password; loginProviderName='tmos'} | ConvertTo-Json
+    #First we attempt to get an auth token. We need an auth token to do anything, include getting the LTM version, for LTMs using external auth.
+    #If we fail to get an auth token, that means the version is prior to 11.6, so we fall back on basic auth
+    $AuthURL = "https://$LTMName/mgmt/shared/authn/login";
+    $JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password; loginProviderName='tmos'} | ConvertTo-Json
 
+    Try {
         $Result = Invoke-RestMethodOverride -Method POST -Uri $AuthURL -Body $JSONBody -Credential $LTMCredentials -ContentType 'application/json'
         $Token = $Result.token.token
         $session.Headers.Add('X-F5-Auth-Token', $Token)
@@ -36,6 +35,10 @@
         $ExpirationTime = $date + $ts
         $session.Headers.Add('Token-Expiration', $ExpirationTime)
     }
+    Catch {
+        Write-Verbose "The version must be prior to 11.6 since we failed to retrieve an auth token."
+        $session.Credentials = $LTMCredentials
+    }
 
     $newSession = [pscustomobject]@{
             Name = $LTMName
@@ -44,7 +47,7 @@
         } | Add-Member -Name GetLink -MemberType ScriptMethod {
                 param($Link)
                 $Link -replace 'localhost', $this.Name    
-            } -PassThru 
+    } -PassThru 
 
     #If the Default switch is set, and/or if no script-scoped F5Session exists, then set the script-scoped F5Session
     If ($Default -or !($Script:F5Session)){

--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -19,8 +19,8 @@
 
     $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-    #First we attempt to get an auth token. We need an auth token to do anything, include getting the LTM version, for LTMs using external auth.
-    #If we fail to get an auth token, that means the version is prior to 11.6, so we fall back on basic auth
+    #First, we attempt to get an authorization token. We need an auth token to do anything for LTMs using external authentication, including getting the LTM version.
+    #If we fail to get an auth token, that means the LTM version is prior to 11.6, so we fall back on basic authorization
     $AuthURL = "https://$LTMName/mgmt/shared/authn/login";
     $JSONBody = @{username = $LTMCredentials.username; password=$LTMCredentials.GetNetworkCredential().password; loginProviderName='tmos'} | ConvertTo-Json
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # POSH-LTM-Rest
 This PowerShell module uses the F5 LTM REST API to manipulate and query pools, pool members, virtual servers and iRules.
 It is built to work with the following BIG-IP versions:
-11.5.1 Build 8.0.175 Hotfix 8 and later
-11.6.0 Build 5.0.429 Hotfix 4 and later
-All versions of 12.x
+   * 11.5.1 Build 8.0.175 Hotfix 8 and later
+   * 11.6.0 Build 5.0.429 Hotfix 4 and later
+   * All versions of 12.x
 
 It requires PowerShell v3 or higher.
 


### PR DESCRIPTION
Changed New-F5Session function to fix an issue creating a new F5 sessions for LTMs using external authentication. Using a Try-Catch for retrieving an auth token. If this fails, we assume LTM version is prior to 11.6 so we use basic auth. For external auth LTMs, we can't check the version without first retrieving an auth token. 