### PR TITLE
Remove-iRule function added, other changes.

### DIFF
--- a/F5-LTM/Public/Deprecated/Get-VirtualServeriRuleCollection.ps1
+++ b/F5-LTM/Public/Deprecated/Get-VirtualServeriRuleCollection.ps1
@@ -11,6 +11,6 @@ Function Get-VirtualServeriRuleCollection {
         [string[]]$Name,
         [Parameter(Mandatory=$false)]$Partition
     )
-    Write-Warning "Get-VirtualServeriRuleCollection is deprecated.  Please use Get-VirtualServer | Select-Object -ExpandProperty rules"
+    Write-Warning "Get-VirtualServeriRuleCollection is deprecated.  Please use Get-VirtualServer | Where-Object rules | Select-Object -ExpandProperty rules"
     Get-VirtualServer -F5Session $F5Session -Name $Name -Partition $Partition | Select-Object -ExpandProperty rules -ErrorAction SilentlyContinue
 }

--- a/F5-LTM/Public/Get-iRule.ps1
+++ b/F5-LTM/Public/Get-iRule.ps1
@@ -35,7 +35,8 @@
                 if(![string]::IsNullOrWhiteSpace($Application) -and ![string]::IsNullOrWhiteSpace($Partition)) {
                     $items = $items | Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"}
                 }
-                $items | Add-ObjectDetail -TypeName 'PoshLTM.iRule'
+                $items | Add-ObjectDetail -TypeName 'PoshLTM.iRule' | Add-Member -MemberType AliasProperty -Name Definition -Value apiAnonymous;
+                $items
             }
         }
     }

--- a/F5-LTM/Public/Remove-iRule.ps1
+++ b/F5-LTM/Public/Remove-iRule.ps1
@@ -1,0 +1,42 @@
+﻿Function Remove-iRule {
+<#
+.SYNOPSIS
+    Remove the specified irule(s). Confirmation is needed.
+#>
+    [cmdletBinding( SupportsShouldProcess=$true, ConfirmImpact='High')]
+    param (
+        $F5Session=$Script:F5Session,
+
+        [Alias('iRule')]
+        [Parameter(Mandatory=$true,ParameterSetName='InputObject',ValueFromPipeline=$true)]
+        [PSObject[]]$InputObject,
+
+        [Alias('iRuleName')]
+        [Parameter(Mandatory=$true,ParameterSetName='Name',ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [string[]]$Name,
+
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [string]$Partition
+    )
+    begin {
+        #Test that the F5 session is in a valid format
+        Test-F5Session($F5Session)
+
+        Write-Verbose "NB: iRule names are case-specific."
+    }
+    process {
+        switch($PSCmdLet.ParameterSetName) {
+            InputObject {
+                foreach($item in $InputObject) {
+                    if ($pscmdlet.ShouldProcess($item.fullPath)){
+                        $URI = $F5Session.GetLink($item.selfLink)
+                        Invoke-F5RestMethod -Method DELETE -Uri $URI -F5Session $F5Session
+                    }
+                }
+            }
+            Name {
+                $Name | Get-iRule -F5Session $F5Session -Partition $Partition | Remove-iRule -F5session $F5Session
+            }
+        }
+    }
+}

--- a/F5-LTM/Public/Remove-iRuleFromVirtualServer.ps1
+++ b/F5-LTM/Public/Remove-iRuleFromVirtualServer.ps1
@@ -20,7 +20,9 @@
         [string]$Partition='Common',
         
         [Parameter(Mandatory=$true)]
-        [string]$iRuleName
+        [string]$iRuleName,
+
+        [switch]$PassThru
     )
     begin {
         #Test that the F5 session is in a valid format
@@ -61,12 +63,17 @@
                 }
             }
             Name {
-                $virtualservers = $Name | Get-VirtualServer -F5Session $F5Session -Partition $Partition
+                $virtualserver = $Name | Get-VirtualServer -F5Session $F5Session -Partition $Partition
 
-                if ($null -eq $virtualservers) {
+                if ($null -eq $virtualserver) {
                     Write-Warning "No virtual servers found."
                 }
-                $virtualservers | Remove-iRuleFromVirtualServer -F5session $F5Session -iRuleName $iRuleName -Partition $Partition
+                else {
+                    $virtualserver = $virtualserver | Remove-iRuleFromVirtualServer -F5session $F5Session -iRuleName $iRuleName -Partition $Partition
+                    If ($PassThru){
+                        $virtualserver
+                    }
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ The module contains the following functions.
    * Get-PoolsForMember
    * Get-StatusShape
    * Get-VirtualServer
-   * Get-VirtualServeriRuleCollection (deprecated; use __Get-VirtualServer | Select -ExpandProperty rules__)
-   * Get-VirtualServerList (deprecated; use __Get-VirtualServer__)
+   * Get-VirtualServeriRuleCollection (deprecated; use __Get-VirtualServer | Where rules | Select -ExpandProperty rules__)
+   * Get-VirtualServerList (deprecated; use __Get-VirtualServer__) 
    * Invoke-RestMethodOverride
    * New-F5Session
    * New-HealthMonitor
@@ -53,6 +53,7 @@ The module contains the following functions.
    * New-Pool
    * New-VirtualServer
    * Remove-HealthMonitor
+   * Remove-iRule
    * Remove-iRuleFromVirtualServer
    * Remove-Pool
    * Remove-PoolMember


### PR DESCRIPTION
Function added: Remove-iRule

Added alias of Definition to returned iRule object.

Only return the modified virtual server after removing an iRule from a virtual server if -PassThru is specified
Small rename in Remove-iRuleFromVirtualServer: virtualservers -> virtualserver

Updated example in deprecated Get-VirtualServeriRuleCollection to handle returning iRules for multiple virtual servers