### PR TITLE
Update Set-Pool.ps1

### DIFF
--- a/F5-LTM/Public/Set-Pool.ps1
+++ b/F5-LTM/Public/Set-Pool.ps1
@@ -60,7 +60,7 @@
         
         [string]$Description,
 
-        [ValidateSet('dynamic-ratio-member','dynamic-ratio-node','fastest-app-response','fastest-node','least-connections-members','least-connections-node','least-sessions','observed-member','observed-node','predictive-member','predictive-node','ratio-least-connections-member','ratio-least-connections-node','ratio-member','ratio-node','ratio-session','round-robin','weighted-least-connections-member','weighted-least-connections-node')]
+        [ValidateSet('dynamic-ratio-member','dynamic-ratio-node','fastest-app-response','fastest-node','least-connections-member','least-connections-node','least-sessions','observed-member','observed-node','predictive-member','predictive-node','ratio-least-connections-member','ratio-least-connections-node','ratio-member','ratio-node','ratio-session','round-robin','weighted-least-connections-member','weighted-least-connections-node')]
         [string]$LoadBalancingMode,
 
         [string[]]$MemberDefinitionList,


### PR DESCRIPTION
Mode is least-connection-member but you have it validate as least-connection-members, which then fails at the F5 as it is an invalid load balancing mode.  Update corrects validation.