### PR TITLE
Joel74

### DIFF
--- a/F5-LTM/Private/Resolve-NestedStats.ps1
+++ b/F5-LTM/Private/Resolve-NestedStats.ps1
@@ -1,0 +1,33 @@
+﻿Function Resolve-NestedStats {
+<#
+.SYNOPSIS
+    Between v11.6 and v12.0, there were breaking changes in regards to the JSON format returned for various iControlREST requests, such as when retrieving the system version or pool member stats.
+    Specifically, instead of the data existing in an "entries" property directly underneath the parent JSON object, it is now enclosed in "nestedStats" property within a custom PS object whose name resembles a self-link with the member name repeated.
+ 
+    To resolve this discrepancy, this function performs version-specific transformations to the JSON data and returns it in a standardized format with the "entries" property at the top.
+#>
+
+    param (
+        $F5Session=$Script:F5Session,
+
+        [Parameter(Mandatory=$true)][string]$JSONData
+    )
+
+    $LTM_VersionArray = $F5Session.LTMVersion.Split(".")
+
+#    $LTM_VersionArray[0] = Major version
+#    $LTM_VersionArray[1] = Minor version
+#    $LTM_VersionArray[2] = Maintenance version
+
+    #Switch based on the major version value
+    switch ($LTM_VersionArray[0])
+    {
+        '11' { <# no conversion needed #> }
+        '12' { $JSON = $JSON.entries.PSObject.Properties.Value.nestedStats; }
+        '13' { $JSON = $JSON.entries.PSObject.Properties.Value.nestedStats; }
+        Default { <# assume no conversion needed #> }
+    }
+
+    $JSON
+
+}

--- a/F5-LTM/Public/Add-PoolMember.ps1
+++ b/F5-LTM/Public/Add-PoolMember.ps1
@@ -99,7 +99,7 @@
                                 $JSONBody = @{name=$Name;partition=$Partition;address=$AddressString;description=$Description}
                                 if ($ExistingNode) {
                                     # Node exists, just add using name
-                                    $JSONBody = @{name=('{0}:{1}' -f $ExistingNode.name,$PortNumber)}
+                                    $JSONBody = @{name=('{0}:{1}' -f $ExistingNode.name,$PortNumber);partition=('{0}' -f $Partition)}
                                 } # else the node will be created
                                 $JSONBody = $JSONBody | ConvertTo-Json
                                 $MembersLink = $F5session.GetLink($pool.membersReference.link)

--- a/F5-LTM/Public/Get-PoolMemberStats.ps1
+++ b/F5-LTM/Public/Get-PoolMemberStats.ps1
@@ -51,6 +51,9 @@
                         "tm:ltm:pool:members:membersstate" {
                             $URI = $F5Session.GetLink(($item.selfLink -replace '\?','/stats?'))
                             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
+
+                            $JSON = Resolve-NestedStats -F5Session $F5Session -JSONData $JSON
+
                             Invoke-NullCoalescing {$JSON.entries} {$JSON} #|
                                 # Add-ObjectDetail -TypeName 'PoshLTM.PoolMemberStats'
                                 # TODO: Establish a type for formatting and return more columns, and consider adding a GetStats() ScriptMethod to PoshLTM.PoolMember  

--- a/F5-LTM/Public/Set-iRule.ps1
+++ b/F5-LTM/Public/Set-iRule.ps1
@@ -57,12 +57,13 @@
                 
         $JSONBody = $JSONBody | ConvertTo-Json -Compress
         
-        #Caused by a bug in ConvertTo-Json https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/11088243-provide-option-to-not-encode-html-special-characte
-        #'<', '>' and ''' are replaced by ConvertTo-Json to \\u003c, \\u003e and \\u0027. The F5 API doesn't understand this. Change them back.
+        # Caused by a bug in ConvertTo-Json https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/11088243-provide-option-to-not-encode-html-special-characte
+        # '<', '>', ''' and '&' are replaced by ConvertTo-Json to \\u003c, \\u003e, \\u0027, and \\u0026. The F5 API doesn't understand this. Change them back.
         $ReplaceChars = @{
             '\\u003c' = '<'
             '\\u003e' = '>'
             '\\u0027' = "'"
+            '\\u0026' = "&"
         }
 
         foreach ($Char in $ReplaceChars.GetEnumerator()) 


### PR DESCRIPTION
This commit fixes the issue with how pool member stats are returned from iControlREST with LTM versions 12.x and 13.x. It implements a private method that transforms the JSON data before returning it. It utilizes a new LTMVersion property of the F5 session object that is retrieved from the LTM and added to the session after the session object is created. Since both the "version info" GET request and the "pool member stats" GET request return data that is enclosed within a nestedStats object when the LTM version is 12.x or 13.x, my thinking is that there may be other functions that need to have their returned JSON transformed to match the JSON that LTM v11.x returns, hence the separate private function. (Issue #61)

Also, this commit fixes an issue with Set-iRule by including "&" in the list of special characters to revert after a ConvertTo-Json call. (Issue #113)

Added a small fix for adding existing nodes to a pool in a non-common partition.