### PR TITLE
Fix #127 RouteDomain,Address inconsistency

### DIFF
--- a/F5-LTM/F5-LTM.psm1
+++ b/F5-LTM/F5-LTM.psm1
@@ -15,7 +15,7 @@
 $Script:F5Session=$null
 
 Add-Type -Path "${PSScriptRoot}\Validation.cs"
-
+Add-Type -Path "${PSScriptRoot}\TypeData\PoshLTM.Types.cs"
 Update-FormatData "${PSScriptRoot}\TypeData\PoshLTM.Format.ps1xml"
 $ScriptPath = Split-Path $MyInvocation.MyCommand.Path
 

--- a/F5-LTM/Private/ArgumentCompletion.ps1
+++ b/F5-LTM/Private/ArgumentCompletion.ps1
@@ -1,3 +1,22 @@
+# Retrieve ALL ~/Public/*.ps1 Command names
+$Script:F5LTMPublicCommands = Get-ChildItem -Path ($PSScriptRoot -replace 'Private','Public') -Filter '*.ps1' -Recurse | Select-Object -ExpandProperty BaseName
+function Get-F5Command {
+<#
+.SYNOPSIS  
+    (Get-Command -Module F5-LTM) adversely affects module import performance.  
+    This is a much faster alternative without resorting to static command names
+    for Register-ArgumentCompleter -Command parameters.
+#>
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        [string[]]$Filter
+    )
+    process{
+        foreach ($f in $filter) {
+            $Script:F5LTMPublicCommands -like $f
+        }
+    }
+}
 function Get-CompleteSession {
     param($boundSession)
     Invoke-NullCoalescing {$boundSession} {$Script:F5Session}
@@ -170,67 +189,67 @@ function CompleteVirtualServerName {
 if (Get-Command Register-ArgumentCompleter -ErrorAction Ignore)
 {
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-PoolMember' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-PoolMember') `
         -ParameterName Address `
         -ScriptBlock $function:CompletePoolMemberAddress
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-PoolMember' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-PoolMember') `
         -ParameterName Name `
         -ScriptBlock $function:CompletePoolMemberName
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-PoolMonitor' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-PoolMonitor') `
         -ParameterName Name `
         -ScriptBlock $function:CompletePoolMonitorName
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-HealthMonitor' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-HealthMonitor') `
         -ParameterName Name `
         -ScriptBlock $function:CompleteMonitorName
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-HealthMonitor' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-HealthMonitor') `
         -ParameterName Type `
         -ScriptBlock $function:CompleteMonitorType
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-Node' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-Node') `
         -ParameterName Address `
         -ScriptBlock $function:CompleteNodeAddress
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-Node' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-Node') `
         -ParameterName Name `
         -ScriptBlock $function:CompleteNodeName
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-Pool' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-Pool') `
         -ParameterName Name `
         -ScriptBlock $function:CompletePoolName
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*') `
         -ParameterName Partition `
         -ScriptBlock $function:CompletePartition
         
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command 'Get-BIGIPPartition' -Module F5-LTM) `
+        -CommandName 'Get-BIGIPPartition' `
         -ParameterName Name `
         -ScriptBlock $function:CompleteBIGIPPartition
         
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-Pool*' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-Pool*') `
         -ParameterName PoolName `
         -ScriptBlock $function:CompletePoolName
         
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-iRule' -Module F5-LTM) `
+        -CommandName 'Get-iRule' `
         -ParameterName Name `
         -ScriptBlock $function:CompleteRuleName
 
     Register-ArgumentCompleter `
-        -CommandName @(Get-Command '*-VirtualServer' -Module F5-LTM) `
+        -CommandName @(Get-F5Command '*-VirtualServer') `
         -ParameterName Name `
         -ScriptBlock $function:CompleteVirtualServerName
 }

--- a/F5-LTM/Public/Add-PoolMember.ps1
+++ b/F5-LTM/Public/Add-PoolMember.ps1
@@ -17,7 +17,7 @@
         [Parameter(Mandatory=$true,ParameterSetName='PoolName',ValueFromPipeline=$true)]
         [string[]]$PoolName,
 
-        [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
         [Alias('ComputerName')]

--- a/F5-LTM/Public/Add-PoolMember.ps1
+++ b/F5-LTM/Public/Add-PoolMember.ps1
@@ -10,11 +10,11 @@
     param (
         $F5Session=$Script:F5Session,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$true,ParameterSetName='InputObject',ValueFromPipeline=$true)]
         [Alias("Pool")]
         [PSObject[]]$InputObject,
 
-        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$true,ParameterSetName='PoolName',ValueFromPipeline=$true)]
         [string[]]$PoolName,
 
         [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
@@ -58,11 +58,8 @@
     }
 
     process {
-#        $Address.IPAddressToString
-#        $PSCmdLet.ParameterSetName
-
-        switch -Wildcard ($PSCmdLet.ParameterSetName) {
-            "InputObjectWith*" {
+        switch ($PSCmdLet.ParameterSetName) {
+            'InputObject' {
                 switch ($InputObject.kind) {
                     "tm:ltm:pool:poolstate" {
                         if ($Address -eq [IPAddress]::any) {
@@ -105,7 +102,7 @@
                     }
                 }
             }
-            "PoolNameWith*" {
+            'PoolName' {
                 foreach($pName in $PoolName) {
 
                     Get-Pool -F5Session $F5Session -PoolName $pName -Partition $Partition -Application $Application | Add-PoolMember -F5session $F5Session -Address $Address -Name $Name -PortNumber $PortNumber -Status $Status -Application $Application

--- a/F5-LTM/Public/Add-PoolMember.ps1
+++ b/F5-LTM/Public/Add-PoolMember.ps1
@@ -20,29 +20,28 @@
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
-        [Alias('ComputerName')]
         [Parameter(Mandatory=$true)]
         [PoshLTM.F5Address]$Address,
 
         [Parameter(Mandatory=$false)]
-        [string]$Name=$Address.ComputerName, # TODO: Verify this default works as intended
+        [string]$Name,
 
         [Parameter(Mandatory=$true)]
         [ValidateRange(0,65535)]
         [int]$PortNumber,
 
         [Parameter(Mandatory=$false)]
-        [string]$Description=$Address.ComputerName,
+        [string]$Description,
 
         [ValidateSet("Enabled","Disabled")]
         [Parameter(Mandatory=$true)]$Status,
-        
+
         [Alias('iApp')]
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Application='',
 
         [Parameter(Mandatory=$false)]
-        [int]$RouteDomain        
+        [int]$RouteDomain
 
     )
 
@@ -64,7 +63,7 @@
                     "tm:ltm:pool:poolstate" {
                         if ($Address -eq [IPAddress]::any) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
-                        } 
+                        }
                         else {
                             $AddressString = $Address.ToString()
                             # Default name to IPAddress
@@ -77,7 +76,7 @@
                             }
                             foreach($pool in $InputObject) {
                                 if (!$Partition) {
-                                    $Partition = $pool.partition 
+                                    $Partition = $pool.partition
                                 }
                                 $JSONBody = @{name=$Name;partition=$Partition;address=$AddressString;description=$Description}
                                 if ($ExistingNode) {

--- a/F5-LTM/Public/Add-PoolMonitor.ps1
+++ b/F5-LTM/Public/Add-PoolMonitor.ps1
@@ -14,7 +14,7 @@
         [Parameter(Mandatory=$true,ParameterSetName='PoolName',ValueFromPipeline=$true)]
         [string[]]$PoolName,
 
-        [Parameter(Mandatory=$false,ParameterSetName='PoolName')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
         
         [Alias('MonitorName')]

--- a/F5-LTM/Public/Deprecated/Get-CurrentConnectionCount.ps1
+++ b/F5-LTM/Public/Deprecated/Get-CurrentConnectionCount.ps1
@@ -13,7 +13,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
-        [string]$Address='*',
+        [string]$Address='0.0.0.0',
 
         [Parameter(Mandatory=$false)]
         [string]$Name='*'

--- a/F5-LTM/Public/Disable-Node.ps1
+++ b/F5-LTM/Public/Disable-Node.ps1
@@ -11,8 +11,8 @@
         [PSObject[]]$InputObject,
 
         [Parameter(Mandatory=$false,ParameterSetName='AddressOrName',ValueFromPipelineByPropertyName=$true)]
-        [string[]]$Address='*',
-
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
+	
         [Alias('ComputerName')]
         [Alias('NodeName')]
         [Parameter(Mandatory=$false,ParameterSetName='AddressOrName',ValueFromPipelineByPropertyName=$true)]

--- a/F5-LTM/Public/Disable-PoolMember.ps1
+++ b/F5-LTM/Public/Disable-PoolMember.ps1
@@ -14,7 +14,7 @@
 
         [Parameter(Mandatory=$true,ParameterSetName='PoolName',ValueFromPipeline=$true)]
         [string[]]$PoolName,
-        [Parameter(Mandatory=$false,ParameterSetName='PoolName')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
         [Alias("ComputerName")]

--- a/F5-LTM/Public/Disable-PoolMember.ps1
+++ b/F5-LTM/Public/Disable-PoolMember.ps1
@@ -18,11 +18,11 @@
         [string]$Partition,
 
         [Alias("ComputerName")]
-        [PoshLTM.F5Address]$Address=[IPAddress]::Any,
+        [PoshLTM.F5Address]$Address=[PoshLTM.F5Address]::Any,
 
         [Parameter(Mandatory=$false)]
         [string]$Name='*',
-        
+
         [switch]$Force
     )
     begin {
@@ -34,7 +34,7 @@
             InputObject {
                 switch ($InputObject.kind) {
                     "tm:ltm:pool:poolstate" {
-                        if ($Address -eq [IPAddress]::Any) {
+                        if ($Address -eq [PoshLTM.F5Address]::Any) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
                             $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session -Force:$Force

--- a/F5-LTM/Public/Disable-PoolMember.ps1
+++ b/F5-LTM/Public/Disable-PoolMember.ps1
@@ -17,7 +17,6 @@
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
-        [Alias("ComputerName")]
         [PoshLTM.F5Address]$Address=[PoshLTM.F5Address]::Any,
 
         [Parameter(Mandatory=$false)]

--- a/F5-LTM/Public/Disable-PoolMember.ps1
+++ b/F5-LTM/Public/Disable-PoolMember.ps1
@@ -18,7 +18,7 @@
         [string]$Partition,
 
         [Alias("ComputerName")]
-        [string]$Address='*',
+        [PoshLTM.F5Address]$Address=[IPAddress]::Any,
 
         [Parameter(Mandatory=$false)]
         [string]$Name='*',
@@ -34,7 +34,7 @@
             InputObject {
                 switch ($InputObject.kind) {
                     "tm:ltm:pool:poolstate" {
-                        if (!$Address) {
+                        if ($Address -eq [IPAddress]::Any) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
                             $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Disable-PoolMember -F5session $F5Session -Force:$Force

--- a/F5-LTM/Public/Enable-Node.ps1
+++ b/F5-LTM/Public/Enable-Node.ps1
@@ -3,22 +3,25 @@
 .SYNOPSIS
     Enable a node to quickly enable all pool members associated with it
 #>
-    [cmdletBinding()]
-    param(
+    [cmdletBinding(DefaultParameterSetName='Address')]
+    param (
         $F5Session=$Script:F5Session,
 
-        [Parameter(Mandatory=$true,ParameterSetName='InputObject',ValueFromPipeline=$true)]
+        [Alias('Node')]
+        [Parameter(Mandatory,ParameterSetName='InputObject',ValueFromPipeline)]
         [PSObject[]]$InputObject,
 
-        [Parameter(Mandatory=$false,ParameterSetName='AddressOrName',ValueFromPipelineByPropertyName=$true)]
-        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
+        [Parameter(Mandatory,ParameterSetName='Address',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='AddressAndName',ValueFromPipelineByPropertyName)]
+        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 
         [Alias('ComputerName')]
         [Alias('NodeName')]
-        [Parameter(Mandatory=$false,ParameterSetName='AddressOrName',ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory,ParameterSetName='Name',ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='AddressAndName',ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [string[]]$Name='',
 
-        [Parameter(Mandatory=$false,ParameterSetName='AddressOrName',ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Partition
     )
     begin {
@@ -27,15 +30,15 @@
     }
     process {
         switch($PSCmdLet.ParameterSetName) {
-            AddressOrName {
-                Get-Node -F5session $F5Session -Address $Address -Partition $Partition -Name $Name | Enable-Node -F5session $F5Session
-            }
             InputObject {
                 $JSONBody = @{state='user-up';session='user-enabled'} | ConvertTo-Json
                 foreach($member in $InputObject) {
                     $URI = $F5Session.GetLink($member.selfLink)
                     Invoke-F5RestMethod -Method PATCH -Uri "$URI" -F5Session $F5Session -Body $JSONBody -ErrorMessage "Failed to enable node $($member.Name)." -AsBoolean
                 }
+            }
+            default {
+                Get-Node -F5session $F5Session -Address $Address -Name $Name -Partition $Partition | Enable-Node -F5session $F5Session
             }
         }
     }

--- a/F5-LTM/Public/Enable-Node.ps1
+++ b/F5-LTM/Public/Enable-Node.ps1
@@ -11,7 +11,7 @@
         [PSObject[]]$InputObject,
 
         [Parameter(Mandatory=$false,ParameterSetName='AddressOrName',ValueFromPipelineByPropertyName=$true)]
-        [string[]]$Address='*',
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
 
         [Alias('ComputerName')]
         [Alias('NodeName')]

--- a/F5-LTM/Public/Enable-PoolMember.ps1
+++ b/F5-LTM/Public/Enable-PoolMember.ps1
@@ -18,7 +18,7 @@
         [string]$Partition,
 
         [Alias("ComputerName")]
-        [PoshLTM.F5Address]$Address=[IPAddress]::Any,
+        [PoshLTM.F5Address]$Address=[PoshLTM.F5Address]::Any,
 
         [string]$Name='*'
     )
@@ -27,7 +27,7 @@
             InputObject {
                 switch ($InputObject.kind) {
                     "tm:ltm:pool:poolstate" {
-                        if ($Address -eq [IPAddress]::Any) {
+                        if ($Address -eq [PoshLTM.F5Address]::Any) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
                             $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session

--- a/F5-LTM/Public/Enable-PoolMember.ps1
+++ b/F5-LTM/Public/Enable-PoolMember.ps1
@@ -18,7 +18,7 @@
         [string]$Partition,
 
         [Alias("ComputerName")]
-        [string]$Address='*',
+        [PoshLTM.F5Address]$Address=[IPAddress]::Any,
 
         [string]$Name='*'
     )
@@ -27,7 +27,7 @@
             InputObject {
                 switch ($InputObject.kind) {
                     "tm:ltm:pool:poolstate" {
-                        if (!$Address) {
+                        if ($Address -eq [IPAddress]::Any) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
                             $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Enable-PoolMember -F5session $F5Session

--- a/F5-LTM/Public/Enable-PoolMember.ps1
+++ b/F5-LTM/Public/Enable-PoolMember.ps1
@@ -17,7 +17,6 @@
         [Parameter(Mandatory=$false,ParameterSetName='PoolName')]
         [string]$Partition,
 
-        [Alias("ComputerName")]
         [PoshLTM.F5Address]$Address=[PoshLTM.F5Address]::Any,
 
         [string]$Name='*'

--- a/F5-LTM/Public/Get-Node.ps1
+++ b/F5-LTM/Public/Get-Node.ps1
@@ -11,7 +11,7 @@
         $F5Session=$Script:F5Session,
 
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
-        [string[]]$Address='*',
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
 
         [Alias('ComputerName')]
         [Alias('NodeName')]
@@ -30,7 +30,7 @@
             $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
             Invoke-NullCoalescing {$JSON.items} {$JSON} | 
-                Where-Object { $Address -eq '*' -or $Address -contains $_.address} |
+                Where-Object { $Address -eq [IPAddress]::Any -or $Address -contains $_.address} |
                 Add-ObjectDetail -TypeName 'PoshLTM.Node'
         }
     }

--- a/F5-LTM/Public/Get-Node.ps1
+++ b/F5-LTM/Public/Get-Node.ps1
@@ -30,7 +30,7 @@
             $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
             Invoke-NullCoalescing {$JSON.items} {$JSON} | 
-                Where-Object { $Address -eq [IPAddress]::Any -or $Address -contains $_.address} |
+                Where-Object { $Address -eq [IPAddress]::Any -or $Address.IPAddress.IPAddressToString -contains $_.address} |
                 Add-ObjectDetail -TypeName 'PoshLTM.Node'
         }
     }

--- a/F5-LTM/Public/Get-Node.ps1
+++ b/F5-LTM/Public/Get-Node.ps1
@@ -30,7 +30,7 @@
             $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
             Invoke-NullCoalescing {$JSON.items} {$JSON} | 
-                Where-Object { $Address -eq [IPAddress]::Any -or $Address.IPAddress.IPAddressToString -contains $_.address} |
+                Where-Object { $Address -eq [IPAddress]::Any -or ([string[]]$Address) -contains $_.address} |
                 Add-ObjectDetail -TypeName 'PoshLTM.Node'
         }
     }

--- a/F5-LTM/Public/Get-Node.ps1
+++ b/F5-LTM/Public/Get-Node.ps1
@@ -28,9 +28,9 @@
         Write-Verbose "NB: Node names are case-specific."
     }
     process {
-        for($i=0; $i -lt $Name.Count -and $i -lt $Address.Count; $i++) {
-            $itemname = $Name[$i]
-            $itemaddress = $Address[$i]
+        for($i=0; $i -lt $Name.Count -or $i -lt $Address.Count; $i++) {
+            $itemname = Invoke-NullCoalescing {$Name[$i]} {''}
+            $itemaddress = Invoke-NullCoalescing {$Address[$i]} {[PoshLTM.F5Address]::Any}
             $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
             Invoke-NullCoalescing {$JSON.items} {$JSON} |

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -45,7 +45,7 @@
                 foreach($pool in $InputObject) {
                     $MembersLink = $F5Session.GetLink($pool.membersReference.link)
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $MembersLink -F5Session $F5Session
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address.IPAddress -eq [IPAddress]::Any -and $Name -eq '*') -or $Address.IPAddress.IPAddressToString -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
+                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address.IPAddress -eq [IPAddress]::Any -and $Name -eq '*') -or ([string[]]$Address) -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {
                         '{0}{1}' -f $this.GetPoolName(),$this.fullPath

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -16,7 +16,7 @@
         [Parameter(Mandatory=$false,ParameterSetName='PoolName',ValueFromPipeline=$true)]
         [string[]]$PoolName='',
 
-        [Parameter(Mandatory=$false,ParameterSetName='PoolName')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
         [Alias("ComputerName")]
@@ -45,7 +45,7 @@
                 foreach($pool in $InputObject) {
                     $MembersLink = $F5Session.GetLink($pool.membersReference.link)
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $MembersLink -F5Session $F5Session
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address -eq [IPAddress]::Any -and $Name -eq '*') -or $Address -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
+                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address.IPAddress -eq [IPAddress]::Any -and $Name -eq '*') -or $Address.IPAddress.IPAddressToString -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {
                         '{0}{1}' -f $this.GetPoolName(),$this.fullPath

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -19,7 +19,6 @@
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
-        [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
         [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -21,7 +21,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
-        [string[]]$Address='*',
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
 
         [Parameter(Mandatory=$false)]
         [string[]]$Name='*',
@@ -37,19 +37,6 @@
         Write-Verbose "NB: Pool and member names are case-specific."
     }
     process {
-        if ($Address -ne '*') {
-            for ([int]$a=0; $a -lt $Address.Count; $a++) {
-                $ip = [IPAddress]::Any
-                if($Address[$a] -match "[\d\.]+%\d+") {
-                    # Do not alter $Address[$a] if in format of IP%Partition
-                } elseif ([IpAddress]::TryParse($Address[$a],[ref]$ip)) {
-                    $Address[$a] = $ip.IpAddressToString
-                } else {
-                    $Address = [string]([System.Net.Dns]::GetHostAddresses($Address).IPAddressToString)
-                    $Address[$a] = $ip
-                }
-            }
-        }
         switch($PSCmdLet.ParameterSetName) {
             InputObject {
                 if ($null -eq $InputObject) {
@@ -58,7 +45,7 @@
                 foreach($pool in $InputObject) {
                     $MembersLink = $F5Session.GetLink($pool.membersReference.link)
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $MembersLink -F5Session $F5Session
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address -eq '*' -and $Name -eq '*') -or $Address -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
+                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address -eq [IPAddress]::Any -and $Name -eq '*') -or $Address -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {
                         '{0}{1}' -f $this.GetPoolName(),$this.fullPath

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -21,7 +21,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
-        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
+        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 
         [Parameter(Mandatory=$false)]
         [string[]]$Name='*',
@@ -45,7 +45,7 @@
                 foreach($pool in $InputObject) {
                     $MembersLink = $F5Session.GetLink($pool.membersReference.link)
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $MembersLink -F5Session $F5Session
-                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { ($Address.IPAddress -eq [IPAddress]::Any -and $Name -eq '*') -or ([string[]]$Address) -contains $_.address -or $Name -contains $_.name } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
+                    Invoke-NullCoalescing {$JSON.items} {$JSON} | Where-Object { [PoshLTM.F5Address]::IsMatch($Address, $_.address) -and ($Name -eq '*' -or $Name -contains $_.name) } | Add-Member -Name GetPoolName -MemberType ScriptMethod {
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {
                         '{0}{1}' -f $this.GetPoolName(),$this.fullPath

--- a/F5-LTM/Public/Get-PoolMemberStats.ps1
+++ b/F5-LTM/Public/Get-PoolMemberStats.ps1
@@ -23,7 +23,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
-        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
+        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 
         [Parameter(Mandatory=$false)]
         [string[]]$Name='*',
@@ -42,7 +42,7 @@
                 foreach($item in $InputObject) {
                     switch ($item.kind) {
                         "tm:ltm:pool:poolstate" {
-                            if ($Address -ne [IPAddress]::Any -or $Name) {
+                            if ($Address -ne [PoshLTM.F5Address]::Any -or $Name) {
                                 $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application | Get-PoolMemberStats -F5session $F5Session
                             } else {
                                 Write-Error 'Address and/or Name is required when the pipeline object is not a PoolMember'
@@ -56,7 +56,7 @@
 
                             Invoke-NullCoalescing {$JSON.entries} {$JSON} #|
                                 # Add-ObjectDetail -TypeName 'PoshLTM.PoolMemberStats'
-                                # TODO: Establish a type for formatting and return more columns, and consider adding a GetStats() ScriptMethod to PoshLTM.PoolMember  
+                                # TODO: Establish a type for formatting and return more columns, and consider adding a GetStats() ScriptMethod to PoshLTM.PoolMember
                         }
                     }
                 }

--- a/F5-LTM/Public/Get-PoolMemberStats.ps1
+++ b/F5-LTM/Public/Get-PoolMemberStats.ps1
@@ -21,7 +21,6 @@
         [Parameter(Mandatory=$false)]
         [string]$Partition,
 
-        [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
         [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 

--- a/F5-LTM/Public/Get-PoolMemberStats.ps1
+++ b/F5-LTM/Public/Get-PoolMemberStats.ps1
@@ -23,7 +23,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
-        [string[]]$Address='*',
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
 
         [Parameter(Mandatory=$false)]
         [string[]]$Name='*',
@@ -42,7 +42,7 @@
                 foreach($item in $InputObject) {
                     switch ($item.kind) {
                         "tm:ltm:pool:poolstate" {
-                            if ($Address -or $Name) {
+                            if ($Address -ne [IPAddress]::Any -or $Name) {
                                 $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application | Get-PoolMemberStats -F5session $F5Session
                             } else {
                                 Write-Error 'Address and/or Name is required when the pipeline object is not a PoolMember'

--- a/F5-LTM/Public/Get-PoolsForMember.ps1
+++ b/F5-LTM/Public/Get-PoolsForMember.ps1
@@ -12,36 +12,21 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false,ParameterSetName='Address')]
-        [string]$Address='*'
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any
     )
     begin {
         #Test that the F5 session is in a valid format
         Test-F5Session($F5Session)
-
-        if ($PSCmdLet.ParameterSetName -eq 'Address') {
-            if ($Address -ne '*') {
-                $ip = [IPAddress]::Any
-                if ([IpAddress]::TryParse($Address,[ref]$ip)) {
-                    $Address = $ip.IpAddressToString
-                } else {
-                    $ip = [string]([System.Net.Dns]::GetHostAddresses($Address).IPAddressToString)
-                    #If we don't get an IP address for the computer, try the value specified
-                    If ($ip) {
-                        $Address = $ip
-                    }
-                }
-            }
-        }
     }
     process {
         switch($PSCmdLet.ParameterSetName) {
             Address {
                 $pools = Get-Pool -F5Session $F5Session
                 foreach ($pool in $pools) {
-                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $_.address -like $Address }
+                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $Address -eq [IPAddress]::Any -or $_.address -like $Address }
                     if ($members) {
                         $pool
-                    }    
+                    }
                 }
             }
             InputObject {

--- a/F5-LTM/Public/Get-PoolsForMember.ps1
+++ b/F5-LTM/Public/Get-PoolsForMember.ps1
@@ -23,7 +23,7 @@
             Address {
                 $pools = Get-Pool -F5Session $F5Session
                 foreach ($pool in $pools) {
-                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $Address -eq [IPAddress]::Any -or $_.address -like $Address }
+                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $Address -eq [IPAddress]::Any -or $_.address -like $Address.IPAddress.IPAddressToString }
                     if ($members) {
                         $pool
                     }

--- a/F5-LTM/Public/Get-PoolsForMember.ps1
+++ b/F5-LTM/Public/Get-PoolsForMember.ps1
@@ -10,7 +10,6 @@
         [Alias('PoolMember')]
         [PSObject]$InputObject,
 
-        [Alias("ComputerName")]
         [Parameter(Mandatory=$false,ParameterSetName='Address')]
         [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any
     )

--- a/F5-LTM/Public/Get-PoolsForMember.ps1
+++ b/F5-LTM/Public/Get-PoolsForMember.ps1
@@ -12,7 +12,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false,ParameterSetName='Address')]
-        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any
+        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any
     )
     begin {
         #Test that the F5 session is in a valid format
@@ -23,7 +23,7 @@
             Address {
                 $pools = Get-Pool -F5Session $F5Session
                 foreach ($pool in $pools) {
-                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $Address -eq [IPAddress]::Any -or $_.address -like ([string[]]$Address) }
+                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { [PoshLTM.F5Address]::IsMatch($Address, $_.address) }
                     if ($members) {
                         $pool
                     }
@@ -31,7 +31,7 @@
             }
             InputObject {
                 foreach($member in $InputObject) {
-                    Get-PoolsForMember -F5Session $F5Session -Address $member.address 
+                    Get-PoolsForMember -F5Session $F5Session -Address $member.address
                 }
             }
         }

--- a/F5-LTM/Public/Get-PoolsForMember.ps1
+++ b/F5-LTM/Public/Get-PoolsForMember.ps1
@@ -23,7 +23,7 @@
             Address {
                 $pools = Get-Pool -F5Session $F5Session
                 foreach ($pool in $pools) {
-                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $Address -eq [IPAddress]::Any -or $_.address -like $Address.IPAddress.IPAddressToString }
+                    $members = $pool | Get-PoolMember -F5session $F5Session | Where-Object { $Address -eq [IPAddress]::Any -or $_.address -like ([string[]]$Address) }
                     if ($members) {
                         $pool
                     }

--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -74,7 +74,7 @@
             }
         }
         # fall back to Credentials
-        Write-Verbose "The version must be prior to 11.6 since we failed to retrieve an auth token but the base URL is valid."
+        Write-Verbose "The version must be prior to 11.6 since we failed to retrieve an auth token."
         $Credential = $LTMCredentials
     }
 

--- a/F5-LTM/Public/New-Pool.ps1
+++ b/F5-LTM/Public/New-Pool.ps1
@@ -51,12 +51,7 @@ Function New-Pool {
                 Invoke-F5RestMethod -Method POST -Uri "$URI" -F5Session $F5Session -Body $JSONBody -ContentType 'application/json' -ErrorMessage ("Failed to create the $($newitem.FullPath) pool.") -AsBoolean
                 ForEach ($MemberDefinition in $MemberDefinitionList){
                     $Node,$PortNumber = $MemberDefinition -split ','
-                    # IP Addresses always start with a number, server names can not
-                    if ($Node -match '^\d') {
-                        $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -Address $Node -PortNumber $PortNumber -Status Enabled
-                    } else {
-                        $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -ComputerName $Node -PortNumber $PortNumber -Status Enabled
-                    }
+                    $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -Address $Node -PortNumber $PortNumber -Status Enabled
                 }
             }
         }

--- a/F5-LTM/Public/New-VirtualServer.ps1
+++ b/F5-LTM/Public/New-VirtualServer.ps1
@@ -4,7 +4,7 @@ Function New-VirtualServer
       .SYNOPSIS
       Create a new virtual server
   #>
-  [cmdletbinding(SupportsShouldProcess = $True,DefaultParameterSetName="VlanEnabled")]   
+  [cmdletbinding(SupportsShouldProcess = $True,DefaultParameterSetName="VlanEnabled")]
   param (
     $F5Session = $Script:F5Session
     ,
@@ -26,7 +26,7 @@ Function New-VirtualServer
     $Description = $null
     ,
     [Parameter(Mandatory = $True)]
-    $DestinationIP
+    [PoshLTM.F5Address]$DestinationIP
     ,
     [Parameter(Mandatory = $True)]
     $DestinationPort
@@ -35,7 +35,7 @@ Function New-VirtualServer
     [string[]]$VlanEnabled
     ,
     [Parameter(Mandatory = $false, ParameterSetName = 'VlanDisabled')]
-    [string[]]$VlanDisabled 
+    [string[]]$VlanDisabled
     ,
     [Parameter(Mandatory = $false)]
     $Source = '0.0.0.0/0'
@@ -86,12 +86,12 @@ Function New-VirtualServer
   {
     Write-Error -Message "The $Name virtual server already exists."
   }
-  Else 
+  Else
   {
     $newitem = New-F5Item -Name $Name -Application $Application -Partition $Partition
 
     #Start building the JSON for the action
-    $Destination = $DestinationIP + ':' + $DestinationPort
+    $Destination = $DestinationIP.ToString() + ':' + $DestinationPort
     $JSONBody = @{
       kind                     = $Kind
       name                     = $newitem.Name
@@ -110,14 +110,14 @@ Function New-VirtualServer
     if ($newItem.application) {
       $JSONBody.Add('application',$newItem.application)
     }
-        
+
     #Extra options for Vlan handling. Sets Vlans for VirtualServer, and sets it to be en- or disabled on those Vlans.
-    If ($VlanEnabled) 
+    If ($VlanEnabled)
     {
       $JSONBody.vlans = $VlanEnabled
       $JSONBody.vlansEnabled = $True
     }
-    elseif ($VlanDisabled) 
+    elseif ($VlanDisabled)
     {
       $JSONBody.vlans = $VlanDisabled
       $JSONBody.vlansDisabled = $True
@@ -138,7 +138,7 @@ Function New-VirtualServer
       #If SourceAddressTranslationType is SNAT, then a value for sourceAddressTranslationPool is expected
       if ($SourceAddressTranslationType -eq 'snat'){
         $SourceAddressTranslation.pool = $SourceAddressTranslationPool
-      }       
+      }
     }
     $JSONBody.sourceAddressTranslation = $SourceAddressTranslation
 

--- a/F5-LTM/Public/Remove-Node.ps1
+++ b/F5-LTM/Public/Remove-Node.ps1
@@ -14,7 +14,7 @@
         [PSObject[]]$InputObject,
 
         [Parameter(Mandatory=$true,ParameterSetName='Address',ValueFromPipelineByPropertyName=$true)]
-        [string[]]$Address='*',
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
 
         [Alias('ComputerName')]
         [Alias('NodeName')]

--- a/F5-LTM/Public/Remove-Node.ps1
+++ b/F5-LTM/Public/Remove-Node.ps1
@@ -1,27 +1,29 @@
 ﻿Function Remove-Node {
 <#
 .SYNOPSIS
-    Remove the specified node(s)
+    Remove the specified Node(s)
 .NOTES
     Node names are case-specific.
 #>
-    [cmdletBinding( SupportsShouldProcess=$true, ConfirmImpact='Medium')]
+    [cmdletBinding( DefaultParameterSetName='Address', SupportsShouldProcess, ConfirmImpact='Medium')]
     param (
         $F5Session=$Script:F5Session,
 
         [Alias('Node')]
-        [Parameter(Mandatory=$true,ParameterSetName='InputObject',ValueFromPipeline=$true)]
+        [Parameter(Mandatory,ParameterSetName='InputObject',ValueFromPipeline)]
         [PSObject[]]$InputObject,
 
-        [Parameter(Mandatory=$true,ParameterSetName='Address',ValueFromPipelineByPropertyName=$true)]
-        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
+        [Parameter(Mandatory,ParameterSetName='Address',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='AddressAndName',ValueFromPipelineByPropertyName)]
+        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 
         [Alias('ComputerName')]
         [Alias('NodeName')]
-        [Parameter(Mandatory=$true,ParameterSetName='Name',ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
-        [string[]]$Name,
+        [Parameter(Mandatory,ParameterSetName='Name',ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='AddressAndName',ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [string[]]$Name='',
 
-        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Partition
     )
     begin {
@@ -32,12 +34,6 @@
     }
     process {
         switch($PSCmdLet.ParameterSetName) {
-            Address {
-                Get-Node -F5Session $F5Session -Address $Address -Partition $Partition | Remove-Node -F5session $F5Session
-            }
-            Name {
-                $Name | Get-Node -F5Session $F5Session -Address $Address -Partition $Partition | Remove-Node -F5session $F5Session
-            }
             InputObject {
                 foreach($item in $InputObject) {
                     if ($pscmdlet.ShouldProcess($item.fullPath)){
@@ -45,6 +41,9 @@
                         Invoke-F5RestMethod -Method DELETE -Uri $URI -F5Session $F5Session
                     }
                 }
+            }
+            default {
+                Get-Node -F5Session $F5Session -Address $Address -Name $Name -Partition $Partition | Remove-Node -F5session $F5Session
             }
         }
     }

--- a/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-LTM/Public/Remove-PoolMember.ps1
@@ -23,7 +23,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
-        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
+        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 
         [Parameter(Mandatory=$false)]
         [string[]]$Name='*',
@@ -42,7 +42,7 @@
                 foreach($item in $InputObject) {
                     switch ($item.kind) {
                         "tm:ltm:pool:poolstate" {
-                            if ($Address -ne [IPAddress]::Any -or $Name) {
+                            if ($Address -ne [PoshLTM.F5Address]::Any -or $Name) {
                                 $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
                             } else {
                                 Write-Error 'Address and/or Name is required when the pipeline object is not a PoolMember'

--- a/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-LTM/Public/Remove-PoolMember.ps1
@@ -21,7 +21,6 @@
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
-        [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
         [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 

--- a/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-LTM/Public/Remove-PoolMember.ps1
@@ -18,7 +18,7 @@
         [Parameter(Mandatory=$true,ParameterSetName='PoolName',ValueFromPipeline=$true)]
         [string[]]$PoolName,
 
-        [Parameter(Mandatory=$false,ParameterSetName='PoolName')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
         [Alias("ComputerName")]

--- a/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-LTM/Public/Remove-PoolMember.ps1
@@ -23,7 +23,7 @@
 
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false)]
-        [string[]]$Address='*',
+        [PoshLTM.F5Address[]]$Address=[IPAddress]::Any,
 
         [Parameter(Mandatory=$false)]
         [string[]]$Name='*',
@@ -42,7 +42,7 @@
                 foreach($item in $InputObject) {
                     switch ($item.kind) {
                         "tm:ltm:pool:poolstate" {
-                            if ($Address -or $Name) {
+                            if ($Address -ne [IPAddress]::Any -or $Name) {
                                 $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
                             } else {
                                 Write-Error 'Address and/or Name is required when the pipeline object is not a PoolMember'

--- a/F5-LTM/Public/Remove-PoolMonitor.ps1
+++ b/F5-LTM/Public/Remove-PoolMonitor.ps1
@@ -15,7 +15,7 @@
 
         [Parameter(Mandatory=$true,ParameterSetName='PoolName',ValueFromPipelineByPropertyName=$true)]
         [string[]]$PoolName,
-        [Parameter(Mandatory=$false,ParameterSetName='PoolName',ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
         [Parameter(Mandatory=$true,ValueFromPipelineByPropertyName=$true)]

--- a/F5-LTM/Public/Set-Pool.ps1
+++ b/F5-LTM/Public/Set-Pool.ps1
@@ -158,13 +158,7 @@
                 # Add requested pool members
                 ForEach ($MemberDefinition in $MemberDefinitionList){
                     $Node,$PortNumber = $MemberDefinition -split ','
-
-                    # IP Addresses always start with a number, server names can not
-                    if ($Node -match '^\d') {
-                        $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -Address $Node -PortNumber $PortNumber -Status Enabled
-                    } else {
-                        $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -ComputerName $Node -PortNumber $PortNumber -Status Enabled
-                    }
+                    $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -Address $Node -PortNumber $PortNumber -Status Enabled
                 }
             }
         }

--- a/F5-LTM/Public/Set-PoolMemberDescription.ps1
+++ b/F5-LTM/Public/Set-PoolMemberDescription.ps1
@@ -19,10 +19,10 @@
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false,ParameterSetName='InputObject')]
         [Parameter(Mandatory=$true,ParameterSetName='PoolName')]
-        [PoshLTM.F5Address]$Address=[IPAddress]::Any,
+        [PoshLTM.F5Address]$Address=[PoshLTM.F5Address]::Any,
 
         [string]$Name='*',
-        
+
         [Parameter(Mandatory=$true)]$Description
     )
     process {
@@ -30,7 +30,7 @@
             InputObject {
                 switch ($InputObject.kind) {
                     "tm:ltm:pool:poolstate" {
-                        if ($Address -eq [IPAddress]::Any) {
+                        if ($Address -eq [PoshLTM.F5Address]::Any) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
                             $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5Session

--- a/F5-LTM/Public/Set-PoolMemberDescription.ps1
+++ b/F5-LTM/Public/Set-PoolMemberDescription.ps1
@@ -19,7 +19,7 @@
         [Alias("ComputerName")]
         [Parameter(Mandatory=$false,ParameterSetName='InputObject')]
         [Parameter(Mandatory=$true,ParameterSetName='PoolName')]
-        [string]$Address='*',
+        [PoshLTM.F5Address]$Address=[IPAddress]::Any,
 
         [string]$Name='*',
         
@@ -30,7 +30,7 @@
             InputObject {
                 switch ($InputObject.kind) {
                     "tm:ltm:pool:poolstate" {
-                        if (!$Address) {
+                        if ($Address -eq [IPAddress]::Any) {
                             Write-Error 'Address is required when the pipeline object is not a PoolMember'
                         } else {
                             $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name | Set-PoolMemberDescription -F5session $F5Session

--- a/F5-LTM/Public/Set-PoolMemberDescription.ps1
+++ b/F5-LTM/Public/Set-PoolMemberDescription.ps1
@@ -16,7 +16,6 @@
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
-        [Alias("ComputerName")]
         [Parameter(Mandatory=$false,ParameterSetName='InputObject')]
         [Parameter(Mandatory=$true,ParameterSetName='PoolName')]
         [PoshLTM.F5Address]$Address=[PoshLTM.F5Address]::Any,
@@ -40,7 +39,7 @@
                         foreach($member in $InputObject) {
                             $JSONBody = @{description=$Description} | ConvertTo-Json
                             $URI = $F5Session.GetLink($member.selfLink)
-                            Invoke-F5RestMethod -Method PATCH -Uri "$URI" -F5Session $F5Session -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to set the description on $ComputerName in the $PoolName pool to $Description." -AsBoolean
+                            Invoke-F5RestMethod -Method PATCH -Uri "$URI" -F5Session $F5Session -Body $JSONBody -ContentType 'application/json' -ErrorMessage "Failed to set the description on $($member.Name) in the $PoolName pool to $Description." -AsBoolean
                         }
                     }
                 }

--- a/F5-LTM/Public/Set-PoolMemberDescription.ps1
+++ b/F5-LTM/Public/Set-PoolMemberDescription.ps1
@@ -13,7 +13,7 @@
 
         [Parameter(Mandatory=$true,ParameterSetName='PoolName',ValueFromPipeline=$true)]
         [string[]]$PoolName,
-        [Parameter(Mandatory=$false,ParameterSetName='PoolName')]
+        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
         [string]$Partition,
 
         [Alias("ComputerName")]

--- a/F5-LTM/Public/Test-Node.ps1
+++ b/F5-LTM/Public/Test-Node.ps1
@@ -35,7 +35,7 @@
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
                     [bool](
                         Invoke-NullCoalescing {$JSON.items} {$JSON} | 
-                        Where-Object { $Address -eq [IPAddress]::Any -or $Address.IPAddress.IPAddressToString -contains $_.address}
+                        Where-Object { $f5address -eq [IPAddress]::Any -or ([string]$itemaddress) -contains $_.address}
                     )
                 }
             }

--- a/F5-LTM/Public/Test-Node.ps1
+++ b/F5-LTM/Public/Test-Node.ps1
@@ -11,7 +11,7 @@
         $F5Session=$Script:F5Session,
 
         [Parameter(Mandatory=$true,ParameterSetName='Address',ValueFromPipelineByPropertyName=$true)]
-        [string[]]$Address,
+        [PoshLTM.F5Address[]]$Address,
 
         [Alias('ComputerName')]
         [Alias('NodeName')]
@@ -35,7 +35,7 @@
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
                     [bool](
                         Invoke-NullCoalescing {$JSON.items} {$JSON} | 
-                        Where-Object { $Address -eq '*' -or $Address -contains $_.address}
+                        Where-Object { $Address -eq [IPAddress]::Any -or $Address -contains $_.address}
                     )
                 }
             }

--- a/F5-LTM/Public/Test-Node.ps1
+++ b/F5-LTM/Public/Test-Node.ps1
@@ -35,7 +35,7 @@
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
                     [bool](
                         Invoke-NullCoalescing {$JSON.items} {$JSON} | 
-                        Where-Object { $Address -eq [IPAddress]::Any -or $Address -contains $_.address}
+                        Where-Object { $Address -eq [IPAddress]::Any -or $Address.IPAddress.IPAddressToString -contains $_.address}
                     )
                 }
             }

--- a/F5-LTM/Public/Test-Node.ps1
+++ b/F5-LTM/Public/Test-Node.ps1
@@ -30,9 +30,9 @@
         Write-Verbose "NB: Node names are case-specific."
     }
     process {
-        for($i=0; $i -lt $Name.Count -and $i -lt $Address.Count; $i++) {
-            $itemname = $Name[$i]
-            $itemaddress = $Address[$i]
+        for($i=0; $i -lt $Name.Count -or $i -lt $Address.Count; $i++) {
+            $itemname = Invoke-NullCoalescing {$Name[$i]} {''}
+            $itemaddress = Invoke-NullCoalescing {$Address[$i]} {[PoshLTM.F5Address]::Any}
             $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session -ErrorAction SilentlyContinue
             [bool](

--- a/F5-LTM/Public/Test-Node.ps1
+++ b/F5-LTM/Public/Test-Node.ps1
@@ -34,8 +34,8 @@
                     $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Partition $Partition)
                     $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
                     [bool](
-                        Invoke-NullCoalescing {$JSON.items} {$JSON} | 
-                        Where-Object { $f5address -eq [IPAddress]::Any -or ([string]$itemaddress) -contains $_.address}
+                        Invoke-NullCoalescing {$JSON.items} {$JSON} |
+                        Where-Object { $itemaddress -eq [IPAddress]::Any -or ([string]$itemaddress) -contains $_.address}
                     )
                 }
             }

--- a/F5-LTM/Public/Test-Node.ps1
+++ b/F5-LTM/Public/Test-Node.ps1
@@ -5,20 +5,22 @@
 .NOTES
     Node names are case-specific.
 #>
-    [cmdletBinding()]
+    [cmdletBinding(DefaultParameterSetName='Address')]
     [OutputType([bool])]
     param (
         $F5Session=$Script:F5Session,
 
-        [Parameter(Mandatory=$true,ParameterSetName='Address',ValueFromPipelineByPropertyName=$true)]
-        [PoshLTM.F5Address[]]$Address,
+        [Parameter(Mandatory,ParameterSetName='Address',ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='AddressAndName',ValueFromPipelineByPropertyName)]
+        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
 
         [Alias('ComputerName')]
         [Alias('NodeName')]
-        [Parameter(Mandatory=$true,ParameterSetName='Name',ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory,ParameterSetName='Name',ValueFromPipeline,ValueFromPipelineByPropertyName)]
+        [Parameter(Mandatory,ParameterSetName='AddressAndName',ValueFromPipeline,ValueFromPipelineByPropertyName)]
         [string[]]$Name='',
 
-        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ValueFromPipelineByPropertyName)]
         [string]$Partition
     )
     begin {
@@ -28,23 +30,15 @@
         Write-Verbose "NB: Node names are case-specific."
     }
     process {
-        switch ($PSCmdlet.ParameterSetName) {
-            Address {
-                foreach ($itemaddress in $Address) {
-                    $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Partition $Partition)
-                    $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
-                    [bool](
-                        Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                        Where-Object { $itemaddress -eq [IPAddress]::Any -or ([string]$itemaddress) -contains $_.address}
-                    )
-                }
-            }
-            Name {
-                foreach ($itemname in $Name) {
-                    $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
-                    Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session -AsBoolean
-                }
-            }
+        for($i=0; $i -lt $Name.Count -and $i -lt $Address.Count; $i++) {
+            $itemname = $Name[$i]
+            $itemaddress = $Address[$i]
+            $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
+            $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session -ErrorAction SilentlyContinue
+            [bool](
+                Invoke-NullCoalescing {$JSON.items} {$JSON} |
+                Where-Object { [PoshLTM.F5Address]::IsMatch($itemaddress, $_.address) }
+            )
         }
     }
 }

--- a/F5-LTM/TypeData/PoshLTM.Types.cs
+++ b/F5-LTM/TypeData/PoshLTM.Types.cs
@@ -1,0 +1,49 @@
+﻿using System;
+namespace PoshLTM
+{
+    public struct F5Address
+    {
+        public string ComputerName;
+        public System.Net.IPAddress IPAddress;
+        public int? RouteDomain;
+
+        public F5Address(string address) {
+            ComputerName = "";
+            if (System.Text.RegularExpressions.Regex.IsMatch(address,"%[0-9]+$")) {
+                IPAddress = System.Net.IPAddress.Parse(address.Split('%')[0]);
+                RouteDomain = int.Parse(address.Split('%')[1]);
+            } else {
+                // IP Addresses always start with a number, server names can not
+                if (System.Text.RegularExpressions.Regex.IsMatch(address,"^[0-9]")) {
+                    IPAddress = System.Net.IPAddress.Parse(address);
+                } else {
+                    ComputerName = address;
+                    IPAddress = System.Net.Dns.GetHostAddresses(ComputerName)[0];
+                }
+                RouteDomain = null;
+            }
+        }
+
+        public override string ToString()
+        {
+            return String.Format("{0}{1:\\%0}", IPAddress, RouteDomain);
+        }
+
+        public static implicit operator F5Address(System.Net.IPAddress value)
+        {
+            return new PoshLTM.F5Address(value.ToString());
+        }
+        public static implicit operator F5Address(string value)
+        {
+            return new PoshLTM.F5Address(value);
+        }
+        public static implicit operator System.Net.IPAddress(F5Address value)
+        {
+            return value.IPAddress;
+        }
+        public static implicit operator string(F5Address value)
+        {
+            return String.Format("{0}{1:\\%0}", value.IPAddress, value.RouteDomain);
+        }
+    }
+}

--- a/F5-LTM/TypeData/PoshLTM.Types.cs
+++ b/F5-LTM/TypeData/PoshLTM.Types.cs
@@ -29,8 +29,8 @@ namespace PoshLTM
                     // IPv6 Addresses do not always start with a number, but resolve nicely
                     // TODO: Is GetHostAddresses[0] sufficient, or should we favor IPv4 addresses?
                     IPAddress = System.Net.Dns.GetHostAddresses(address)[0];
-                    // If IPv4 the input string wasn't IPv6 so save the input as ComputerName for reference
-                    if (IPAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork) {
+                    // If the input string is equal to the IPAddress the input is probably IPv6.  If not save the input as ComputerName for reference.
+                    if (!IPAddress.ToString().Equals(address)) {
                         ComputerName = address;
                     }
                 }
@@ -54,11 +54,13 @@ namespace PoshLTM
             }
             if (obj is System.Net.IPAddress)
             {
-                return this.IPAddress.Equals((System.Net.IPAddress)obj);
+                var f5address = new PoshLTM.F5Address(((System.Net.IPAddress)obj).ToString());
+                return this.Equals(f5address);
             }
             if (obj is string)
             {
-                return this.ToString().Equals((string)obj);
+                var f5address = new PoshLTM.F5Address((string)obj);
+                return this.Equals(f5address);
             }
             return false;
         }

--- a/F5-LTM/TypeData/PoshLTM.Types.cs
+++ b/F5-LTM/TypeData/PoshLTM.Types.cs
@@ -3,24 +3,94 @@ namespace PoshLTM
 {
     public struct F5Address
     {
+        public static PoshLTM.F5Address Any = System.Net.IPAddress.Any;
         public string ComputerName;
         public System.Net.IPAddress IPAddress;
         public int? RouteDomain;
 
-        public F5Address(string address) {
+        public F5Address(string address)
+        {
             ComputerName = "";
-            if (System.Text.RegularExpressions.Regex.IsMatch(address,"%[0-9]+$")) {
+            // TODO: Implement ComputerName%RouteDomain syntax?
+            if (System.Text.RegularExpressions.Regex.IsMatch(address,"%[0-9]+$"))
+            {
                 IPAddress = System.Net.IPAddress.Parse(address.Split('%')[0]);
                 RouteDomain = int.Parse(address.Split('%')[1]);
-            } else {
-                // IP Addresses always start with a number, server names can not
-                if (System.Text.RegularExpressions.Regex.IsMatch(address,"^[0-9]")) {
+            }
+            else
+            {
+                // IPv4 Addresses always start with a number, server names can not
+                if (System.Text.RegularExpressions.Regex.IsMatch(address,"^[0-9]"))
+                {
                     IPAddress = System.Net.IPAddress.Parse(address);
-                } else {
-                    ComputerName = address;
-                    IPAddress = System.Net.Dns.GetHostAddresses(ComputerName)[0];
+                }
+                else
+                {
+                    // IPv6 Addresses do not always start with a number, but resolve nicely
+                    // TODO: Is GetHostAddresses[0] sufficient, or should we favor IPv4 addresses?
+                    IPAddress = System.Net.Dns.GetHostAddresses(address)[0];
+                    // If IPv4 the input string wasn't IPv6 so save the input as ComputerName for reference
+                    if (IPAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork) {
+                        ComputerName = address;
+                    }
                 }
                 RouteDomain = null;
+            }
+        }
+
+        #region Override Equals
+
+        // https://msdn.microsoft.com/ru-ru/library/ms173147(v=vs.80).aspx
+        public override bool Equals(System.Object obj)
+        {
+            // If parameter is null return false.
+            if (obj == null)
+            {
+                return false;
+            }
+            if (obj is PoshLTM.F5Address)
+            {
+                return this.Equals((PoshLTM.F5Address)obj);
+            }
+            if (obj is System.Net.IPAddress)
+            {
+                return this.IPAddress.Equals((System.Net.IPAddress)obj);
+            }
+            if (obj is string)
+            {
+                return this.ToString().Equals((string)obj);
+            }
+            return false;
+        }
+
+        public bool Equals(PoshLTM.F5Address other)
+        {
+            return IPAddress.Equals(other.IPAddress) && RouteDomain.Equals(other.RouteDomain) && ComputerName.Equals(ComputerName);
+        }
+
+        // Required to override Equals
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
+
+        #endregion
+
+        // This differs from Equals: it will match on IP alone if no RouteDomain criteria is specified.
+        public bool IsMatch(string address)
+        {
+            // Built-in matching for the default (Any) filter
+            if (this.Equals(Any)) {
+                return true;
+            }
+            if (RouteDomain.HasValue)
+            {
+                return this.ToString() == address;
+            }
+            else
+            {
+                PoshLTM.F5Address f5address = new PoshLTM.F5Address(address);
+                return IPAddress.ToString() == f5address.IPAddress.ToString();
             }
         }
 
@@ -29,21 +99,36 @@ namespace PoshLTM
             return String.Format("{0}{1:\\%0}", IPAddress, RouteDomain);
         }
 
-        public static implicit operator F5Address(System.Net.IPAddress value)
+        public static implicit operator PoshLTM.F5Address(System.Net.IPAddress value)
         {
             return new PoshLTM.F5Address(value.ToString());
         }
-        public static implicit operator F5Address(string value)
+        public static implicit operator PoshLTM.F5Address(string value)
         {
             return new PoshLTM.F5Address(value);
         }
-        public static implicit operator System.Net.IPAddress(F5Address value)
+        public static implicit operator System.Net.IPAddress(PoshLTM.F5Address value)
         {
             return value.IPAddress;
         }
-        public static implicit operator string(F5Address value)
+        public static implicit operator string(PoshLTM.F5Address value)
         {
             return String.Format("{0}{1:\\%0}", value.IPAddress, value.RouteDomain);
+        }
+        public static bool IsMatch(PoshLTM.F5Address filter, string address)
+        {
+            return filter.IsMatch(address);
+        }
+        public static bool IsMatch(PoshLTM.F5Address[] filter, string address)
+        {
+            foreach(PoshLTM.F5Address f in filter)
+            {
+                if (f.IsMatch(address))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
I used C# to define a PoshLTM.F5Address type (struct) which is composed
of a ComputerName, IPAddress and RouteDomain.  GetHostAddresses
functionality has been encapsulated in the new struct.  This adds
support for computername and routedomain throughout the module without
the redundant supporting conditional logic in each Function affected.