### PR TITLE
Fixing issues 133 and 134

### DIFF
--- a/F5-LTM/Public/New-Pool.ps1
+++ b/F5-LTM/Public/New-Pool.ps1
@@ -50,8 +50,8 @@ Function New-Pool {
 
                 Invoke-F5RestMethod -Method POST -Uri "$URI" -F5Session $F5Session -Body $JSONBody -ContentType 'application/json' -ErrorMessage ("Failed to create the $($newitem.FullPath) pool.") -AsBoolean
                 ForEach ($MemberDefinition in $MemberDefinitionList){
-                    $Node,$PortNumber = $MemberDefinition -split ','
-                    $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -Address $Node -PortNumber $PortNumber -Status Enabled
+                    $Node,$PortNumber,$Description = $MemberDefinition -split ','
+                    $null = Add-PoolMember -F5Session $F5Session -PoolName $Name -Partition $Partition -Address $Node -PortNumber $PortNumber -Description $Description -Status Enabled
                 }
             }
         }

--- a/F5-LTM/Public/Test-Functionality.ps1
+++ b/F5-LTM/Public/Test-Functionality.ps1
@@ -89,11 +89,18 @@
     $virtualServers = Get-VirtualServer -F5Session $F5Session | Select-Object -ExpandProperty fullPath
     $virtualServers
 
-    Write-Host ("`r`n* Test whether the first virtual server in the list - " +  $virtualServers[0] + " - exists") -ForegroundColor $TestNotesColor
-    Test-VirtualServer -F5Session $F5Session -VirtualServerName $virtualServers[0]
+    If ($virtualServers -is [array]){
+        $firstVirtualServer = $virtualServers[0]
+    }
+    Else {
+        $firstVirtualServer = $virtualServers
+    }
 
-    Write-Host ("`r`n* Get the virtual server '" + $virtualServers[0] + "'") -ForegroundColor $TestNotesColor
-    Get-VirtualServer -F5Session $F5Session -VirtualServerName $virtualServers[0]
+    Write-Host ("`r`n* Test whether the first virtual server in the list - " +  $firstVirtualServer + " - exists") -ForegroundColor $TestNotesColor
+    Test-VirtualServer -F5Session $F5Session -VirtualServerName $firstVirtualServer
+
+    Write-Host ("`r`n* Get the virtual server '" + $firstVirtualServer + "'") -ForegroundColor $TestNotesColor
+    Get-VirtualServer -F5Session $F5Session -VirtualServerName $firstVirtualServer
 
     Write-Host "`r`n* Create a new virtual server named '$TestVirtualServer'" -ForegroundColor $TestNotesColor
     New-VirtualServer -F5Session $F5Session -VirtualServerName $TestVirtualServer -Description 'description' -DestinationIP $TestVirtualServerIP -DestinationPort '80' -DefaultPool $TestPool -IPProtocol 'tcp' -ProfileNames 'http'


### PR DESCRIPTION
Added Description to pool member definition list split. Otherwise, adding a pool member to a new pool fails.

For showing virtual servers in Test-Functionality, we have to check whether the returned virtual server(s) are an object or an array.

Fixing issues #133 and #134