### PR TITLE
JN: Updating *-PoolMember and Get-Node functions to support FQDN node…

### DIFF
--- a/F5-LTM/Public/Get-Node.ps1
+++ b/F5-LTM/Public/Get-Node.ps1
@@ -34,7 +34,8 @@
             $URI = $F5Session.BaseURL + 'node/{0}' -f (Get-ItemPath -Name $itemname -Partition $Partition)
             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
             Invoke-NullCoalescing {$JSON.items} {$JSON} |
-                Where-Object { [PoshLTM.F5Address]::IsMatch($itemaddress, $_.address) } |
+                Where-Object { $_.ephemeral -eq 'false' } | 
+                Where-Object { [PoshLTM.F5Address]::IsMatch($itemaddress, $_.address)  } |
                 Add-ObjectDetail -TypeName 'PoshLTM.Node'
         }
     }

--- a/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-LTM/Public/Remove-PoolMember.ps1
@@ -22,7 +22,7 @@
         [string]$Partition,
 
         [Parameter(Mandatory=$false)]
-        [PoshLTM.F5Address[]]$Address=[PoshLTM.F5Address]::Any,
+        [PoshLTM.F5Address[]]$Address,
 
         [Parameter(Mandatory=$false)]
         [string[]]$Name='*',
@@ -41,9 +41,12 @@
                 foreach($item in $InputObject) {
                     switch ($item.kind) {
                         "tm:ltm:pool:poolstate" {
-                            if ($Address -ne [PoshLTM.F5Address]::Any -or $Name) {
-                                $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
-                            } else {
+                            if ($Address -eq [PoshLTM.F5Address]::Any) {
+                                $InputObject | Get-PoolMember -F5session $F5Session -Address $Address -Application $Application | Remove-PoolMember -F5session $F5Session
+                            } elseif ($Name) {
+                                $InputObject | Get-PoolMember -F5session $F5Session -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
+                            }
+                            else {
                                 Write-Error 'Address and/or Name is required when the pipeline object is not a PoolMember'
                             }
                         }
@@ -57,7 +60,12 @@
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
+                    If ($Address){
+                        Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Application $Application | Remove-PoolMember -F5session $F5Session
+                    }
+                    Else {
+                        Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
+                    }
             }
         }
     }


### PR DESCRIPTION
…s, and correspondingly, to not require an IP address be passed in. When a pool member is an FQDN node, the IP will be ephemeral and not required, so not passing in an IP address should be allowed.