### PR TITLE
Re #166 if the error returned isn't JSON, treat it as a string

### DIFF
--- a/F5-LTM/Private/Invoke-F5RestMethod.ps1
+++ b/F5-LTM/Private/Invoke-F5RestMethod.ps1
@@ -36,7 +36,12 @@ Function Invoke-F5RestMethod {
         if ($AsBoolean) {
             $false
         } else {
-            $message = $_.ErrorDetails.Message | ConvertFrom-json | Select-Object -expandproperty message
+            #Try to treat the returned error as JSON. If it isn't, then treat it as a string
+            try {
+                $message = $_.ErrorDetails.Message | ConvertFrom-json | Select-Object -expandproperty message
+            } catch {
+                $message = [string]$_.ErrorDetails.Message 
+            }
             $ErrorOutput = '"{0} {1}: {2}' -f $_.Exception.Response.StatusCode.value__,$_.Exception.Response.StatusDescription,(Invoke-NullCoalescing {$message} {$ErrorMessage}) 
             Write-Error $ErrorOutput
         } 


### PR DESCRIPTION
If we fail to convert the error message to JSON, then treat it as a string.