### PR TITLE
Fix error in New-VirtualServer when -PersistenceProfiles is empty and added -SecurityLogProfiles and -PolicyNames

### DIFF
--- a/F5-LTM/Public/Get-VirtualServer.ps1
+++ b/F5-LTM/Public/Get-VirtualServer.ps1
@@ -54,8 +54,8 @@
                 $subcollections = [Array] $items | Get-Member -MemberType NoteProperty | % Name | %  { $items.$_ } | Where { $_.isSubcollection -eq 'True' } 
 
                 #Add properties for policies and profiles
-                $items | Add-Member -NotePropertyName 'policies' -NotePropertyValue ''
-                $items | Add-Member -NotePropertyName 'profiles' -NotePropertyValue ''
+                $items | Add-Member -NotePropertyName 'policies' -NotePropertyValue @()
+                $items | Add-Member -NotePropertyName 'profiles' -NotePropertyValue @()
 
                 ForEach ($sub in $subcollections)
                 {

--- a/F5-LTM/Public/New-VirtualServer.ps1
+++ b/F5-LTM/Public/New-VirtualServer.ps1
@@ -103,10 +103,15 @@ Function New-VirtualServer
       ipProtocol               = $ipProtocol
       mask                     = $Mask
       connectionLimit          = $ConnectionLimit
-      persist                  = $PersistenceProfiles
       fallbackPersistence      = $FallbackPersistence
 
     }
+
+    if ($PersistenceProfiles)
+    {
+      $JSONBody.persist = $PersistenceProfiles
+    }
+
     if ($newItem.application) {
       $JSONBody.Add('application',$newItem.application)
     }

--- a/F5-LTM/Public/New-VirtualServer.ps1
+++ b/F5-LTM/Public/New-VirtualServer.ps1
@@ -72,6 +72,12 @@ Function New-VirtualServer
     ,
     [Parameter(Mandatory = $false)]
     [string]$FallbackPersistence
+    ,
+    [Parameter(Mandatory = $false)]
+    [string[]]$SecurityLogProfiles
+    ,
+    [Parameter(Mandatory = $false)]
+    [string[]]$PolicyNames = $null
 
 
   )
@@ -110,6 +116,10 @@ Function New-VirtualServer
     if ($PersistenceProfiles)
     {
       $JSONBody.persist = $PersistenceProfiles
+    }
+    if ($SecurityLogProfiles)
+    {
+      $JSONBody.securityLogProfiles = $SecurityLogProfiles
     }
 
     if ($newItem.application) {
@@ -157,6 +167,20 @@ Function New-VirtualServer
       }
     }
     $JSONBody.profiles = $ProfileItems
+
+    #Build array of policy items
+    $PolicyItems = @()
+    ForEach ($PolicyName in $PolicyNames)
+    {
+      $PolicyItems += @{
+        kind = 'tm:ltm:virtual:policies:policiesstate'
+        name = $PolicyName
+      }
+    }
+    if ($PolicyItems.Count -gt 0)
+    {
+      $JSONBody.policies = $PolicyItems
+    }
 
     $JSONBody = $JSONBody | ConvertTo-Json
 

--- a/F5-LTM/Public/Set-VirtualServer.ps1
+++ b/F5-LTM/Public/Set-VirtualServer.ps1
@@ -133,6 +133,9 @@ Function Set-VirtualServer {
         [ValidateSet('tcp','udp','sctp')]
         $ipProtocol=$null
         ,
+        [Parameter(Mandatory = $false)]
+        [string[]]$PolicyNames=$null
+        ,
         #endregion
 
         #endregion
@@ -195,6 +198,17 @@ Function Set-VirtualServer {
                     }
                     $ChgProperties['profiles'] = $ProfileItems
                 }
+                'PolicyNames' {
+                    $NewProperties[$key] = $PSBoundParameters[$key]
+                    $PolicyItems = @()
+                    ForEach ($PolicyName in $PolicyNames) {
+                        $PolicyItems += @{
+                            kind = 'tm:ltm:virtual:policies:policiesstate'
+                            name = $PolicyName
+                        }
+                    }
+                    $ChgProperties['policies'] = $PolicyItems
+                }
                 'InputObject' {} # Ignore
                 'PassThru' {} # Ignore
                 { @('VlanEnabled','VlanDisabled') -contains $_ } {
@@ -247,7 +261,9 @@ Function Set-VirtualServer {
             Write-Verbose -Message 'Setting VirtualServer details...'
 
             $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $Name -Application $Application -Partition $Partition)
-            $JSONBody = $NewObject | ConvertTo-Json -Compress
+            # The default depth of ConvertTo-Json is 2.
+            # We need at least a depth of 3 for working with virtual servers that have a persistence profile set.
+            $JSONBody = $NewObject | ConvertTo-Json -Compress -Depth 10
 
             #region case-sensitive parameter names
 


### PR DESCRIPTION
Currently New-VirtualServer crashes with the following error message, when no or an empty -PersistenceProfiles is given:
```
Invoke-F5RestMethod : "400 Bad Request: one or more configuration identifiers must be provided
At C:\Program Files\WindowsPowerShell\Modules\f5-ltm\1.4.239\Public\New-VirtualServer.ps1:160 char:7
+       Invoke-F5RestMethod -Method POST -Uri "$URI" `
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Invoke-F5RestMethod
```
I've fixed that, by only adding it to the JSONBody if defined.

Background: We have a special case where we really do not want any persistence profiles set on a bunch of our virtual servers for a specific WebApp.