### PR TITLE
Fixing issues with filtering pool members for uniqueness and returning a warning if remove-poolmember does nothing

### DIFF
--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -49,7 +49,7 @@
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {
                         '{0}{1}' -f $this.GetPoolName(),$this.fullPath
-                    } -Force -PassThru | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'
+                    } -Force -PassThru | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember' | Select-Object -Unique
                 }
             }
             PoolName {

--- a/F5-LTM/Public/Get-PoolMember.ps1
+++ b/F5-LTM/Public/Get-PoolMember.ps1
@@ -49,11 +49,11 @@
                         [Regex]::Match($this.selfLink, '(?<=pool/)[^/]*') -replace '~','/'
                     } -Force -PassThru | Add-Member -Name GetFullName -MemberType ScriptMethod {
                         '{0}{1}' -f $this.GetPoolName(),$this.fullPath
-                    } -Force -PassThru | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember' | Select-Object -Unique
+                    } -Force -PassThru | Add-ObjectDetail -TypeName 'PoshLTM.PoolMember'                     
                 }
             }
             PoolName {
-                Get-Pool -F5Session $F5Session -Name $PoolName -Partition $Partition -Application $Application | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application
+                Get-Pool -F5Session $F5Session -Name $PoolName -Partition $Partition -Application $Application | Get-PoolMember -F5session $F5Session -Address $Address -Name $Name -Application $Application | Sort-object Name | Get-Unique –AsString
             }
         }
     }

--- a/F5-LTM/Public/Get-PoolsForMember.ps1
+++ b/F5-LTM/Public/Get-PoolsForMember.ps1
@@ -1,7 +1,11 @@
 ﻿Function Get-PoolsForMember {
 <#
-.SYNOPSIS
-    Determine which pool(s) a server is in
+    .SYNOPSIS
+        Determine which pool(s) a pool member is in. Expects either a pool member object or an IP address to be passed as a parameter
+    .EXAMPLE
+        #Get all pools that 'member1' pool member is in
+        Get-poolmember -Name 'member1' | Get-PoolsForMember
+
 #>
     [cmdletBinding()]
     param(

--- a/F5-LTM/Public/Remove-PoolMember.ps1
+++ b/F5-LTM/Public/Remove-PoolMember.ps1
@@ -57,7 +57,13 @@
                 }
             }
             PoolName {
-                Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name -Application $Application | Remove-PoolMember -F5session $F5Session
+                $PoolMember = Get-PoolMember -F5session $F5Session -PoolName $PoolName -Partition $Partition -Address $Address -Name $Name -Application $Application;
+                If ($PoolMember) { 
+                    $PoolMember | Remove-PoolMember -F5session $F5Session
+                }
+                Else {
+                    Write-Warning "Pool member not found"
+                }
             }
         }
     }


### PR DESCRIPTION
If a pool member is a member of multiple pools, then get-poolmember would return multiple instances. This should be filtered for uniqueness.
Also, if remove-poolmember is passed a poo member that doesn't exist, then this should return a warning.
Lastly, adding an example to Get-PoolsForMember.ps1