### PR TITLE
fixes for issues #173 and #175. Additional notes and requiring TLS 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+appveyor.yml

--- a/F5-LTM/F5-LTM.psm1
+++ b/F5-LTM/F5-LTM.psm1
@@ -3,7 +3,7 @@
     A module for using the F5 LTM REST API to administer an LTM device
 .DESCRIPTION  
     This module uses the F5 LTM REST API to manipulate and query pools, pool members, virtual servers and iRules
-    It is built to work with version 11.6
+    It is built to work with version 11.6 and higher
 .NOTES  
     File Name    : F5-LTM.psm1
     Author       : Joel Newton - jnewton@springcm.com
@@ -18,6 +18,10 @@ Add-Type -Path "${PSScriptRoot}\Validation.cs"
 Add-Type -Path "${PSScriptRoot}\TypeData\PoshLTM.Types.cs"
 Update-FormatData "${PSScriptRoot}\TypeData\PoshLTM.Format.ps1xml"
 $ScriptPath = Split-Path $MyInvocation.MyCommand.Path
+
+#Restrict .NET Framework to TLS v 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 #region Load Public Functions
 
     Get-ChildItem "$ScriptPath\Public" -Filter *.ps1 -Recurse| Select-Object -Expand FullName | ForEach-Object {

--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -7,6 +7,7 @@
     for a user with permissions to work with the REST API. Based on the scope value, it either returns the 
     session object (local scope) or adds the session object to the script scope
     It takes an optional parameter of TokenLifespan, a value in seconds between 300 and 36000 (5 minutes and 10 hours).
+    NB: If you need to connect to an LTM on other than the standard HTTPS port of 443, please include that port in the LTM name. I.e. $LTMName = '192.168.1.1:8443'
 #>
     [cmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]

--- a/F5-LTM/Public/New-Pool.ps1
+++ b/F5-LTM/Public/New-Pool.ps1
@@ -11,6 +11,7 @@ Function New-Pool {
 .EXAMPLE
     # The MemberDefinitionList can accept a server name / IP address, a port number, a description and a route domain value.
     New-Pool -F5Session $F5Session -PoolName "MyPoolName" -MemberDefinitionList @("Server1,80,Web server,1","Server2,443,Another web server,2")
+    If you don't use route domains, leave that value blank.
 
 #>   
     [cmdletBinding()]

--- a/F5-LTM/Public/Set-VirtualServer.ps1
+++ b/F5-LTM/Public/Set-VirtualServer.ps1
@@ -46,7 +46,6 @@ Function Set-VirtualServer {
             #Add the profiles member to the virtual server object
             $vs | Add-Member -Name 'profiles' -Value $ProfileItems -MemberType NoteProperty
 
-
             #Define the persistence profiles to apply
             $PersistenceProfiles = @('hash','cookie')
             $PersistItems = @()
@@ -61,7 +60,7 @@ Function Set-VirtualServer {
 
 
             #Add the fallbackPersistence member to the virtual server object
-            $vs | Add-Member 'fallbackPersistence' -Value 'source_addr'
+			$vs | Add-Member -Name 'fallbackPersistence' -Value 'source_addr' -MemberType NoteProperty
 
             #Set the virtual server by passing the modified local object to the LTM
             $vs | Set-VirtualServer

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It is built to work with the following BIG-IP versions:
    * All versions of 12.x
 
 It requires PowerShell v3 or higher.
+It is set to negotiate connections using TLS 1.2. TLS 1.2 is only supported on .NET Framework 4.5+.
 
 It includes a Validation.cs class file (based on code posted by Brian Scholer on www.briantist.com) to allow for using the REST API with LTM devices using self-signed SSL certificates.
 
@@ -68,7 +69,7 @@ The module contains the following functions.
    * Remove-Node
    * Remove-ProfileHttp
    * Remove-VirtualServer
-   * Set-iRule
+   * Set-iRule (used to both create and update)
    * Set-PoolLoadBalancingMode (deprecated; use __Set-Pool__)
    * Set-PoolMemberDescription
    * Set-Pool

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ os: WMF 5
 environment:
   # Encrypted PowerShellGallery API Key to facilitate publishing
   # See https://ci.appveyor.com/tools/encrypt
-  POWERSHELLGALLERY_APIKEY:
-    secure: NvJlPynne4N7tJ/8DM2LFAKoZu5v9e35PvbAJNOCiXbXJRHrJ+OetTQsO/bYjNo5
+  # POWERSHELLGALLERY_APIKEY:
+  #   secure: NvJlPynne4N7tJ/8DM2LFAKoZu5v9e35PvbAJNOCiXbXJRHrJ+OetTQsO/bYjNo5
   
 skip_commits:
   # Skip on updates to the readme. [skip ci] or [ci skip] anywhere in commit message will also prevent a ci build 
@@ -45,4 +45,5 @@ test_script:
   
 deploy_script:
   # Publish module to the PowerShellGallery
-  - ps: Publish-Module -NugetApiKey $env:POWERSHELLGALLERY_APIKEY -Path (Join-Path $env:APPVEYOR_BUILD_FOLDER 'F5-LTM')
+  # JN: Since this is a dev branch, don't publish it to PSGallery
+  #  - ps: Publish-Module -NugetApiKey $env:POWERSHELLGALLERY_APIKEY -Path (Join-Path $env:APPVEYOR_BUILD_FOLDER 'F5-LTM')

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ os: WMF 5
 environment:
   # Encrypted PowerShellGallery API Key to facilitate publishing
   # See https://ci.appveyor.com/tools/encrypt
-  # POWERSHELLGALLERY_APIKEY:
-  #   secure: NvJlPynne4N7tJ/8DM2LFAKoZu5v9e35PvbAJNOCiXbXJRHrJ+OetTQsO/bYjNo5
+  POWERSHELLGALLERY_APIKEY:
+    secure: NvJlPynne4N7tJ/8DM2LFAKoZu5v9e35PvbAJNOCiXbXJRHrJ+OetTQsO/bYjNo5
   
 skip_commits:
   # Skip on updates to the readme. [skip ci] or [ci skip] anywhere in commit message will also prevent a ci build 


### PR DESCRIPTION
The main change is that TLS 1.2 will be explicitly required for invoke rest method calls.