### PR TITLE
Joel74 dev

### DIFF
--- a/F5-LTM/F5-LTM.psm1
+++ b/F5-LTM/F5-LTM.psm1
@@ -15,7 +15,10 @@
 $Script:F5Session=$null
 
 Add-Type -Path "${PSScriptRoot}\Validation.cs"
-Add-Type -Path "${PSScriptRoot}\TypeData\PoshLTM.Types.cs"
+#Only add this type if it isn't already added to the session
+if (!("PoshLTM.F5Address" -as [type])) {
+    Add-Type -Path "${PSScriptRoot}\TypeData\PoshLTM.Types.cs"
+}
 Update-FormatData "${PSScriptRoot}\TypeData\PoshLTM.Format.ps1xml"
 $ScriptPath = Split-Path $MyInvocation.MyCommand.Path
 


### PR DESCRIPTION
Added additional params to Get-VirtualServer. Excluding subcollections has a significant performance increase (couple orders of magnitude) for LTMs with 1000's of virtual servers. Added an Address param to Get-VirtualServer to allow for only returning the virtual server that matches that IP.

In the module file, I had been getting errors if PoshLTM.Types.cs was already loaded into the PS session, so I added a check for that.