### PR TITLE
Changing Test-F5Session to allow using the default, script-scoped F5s…

### DIFF
--- a/F5-LTM/Public/Get-VirtualServer.ps1
+++ b/F5-LTM/Public/Get-VirtualServer.ps1
@@ -33,10 +33,8 @@ Function Get-VirtualServer{
         [string]$Partition,
 
         [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
-        [PoshLTM.F5Address[]]$Address,
+        [PoshLTM.F5Address[]]$Address
 
-        [Parameter(Mandatory=$false,ValueFromPipelineByPropertyName=$true)]
-        [switch]$ExcludeSubcollections
     )
     begin {
         #Test that the F5 session is in a valid format
@@ -48,7 +46,7 @@ Function Get-VirtualServer{
 
         foreach ($vsname in $Name) {
 
-            $URI = $F5Session.BaseURL + 'virtual/{0}' -f (Get-ItemPath -Name $vsname -Application $Application -Partition $Partition)
+            $URI = $F5Session.BaseURL + 'virtual/{0}?expandSubcollections=true' -f (Get-ItemPath -Name $vsname -Application $Application -Partition $Partition)
             $JSON = Invoke-F5RestMethod -Method Get -Uri $URI -F5Session $F5Session
             if ($JSON.items -or $JSON.name) {
                 $items = Invoke-NullCoalescing {$JSON.items} {$JSON}
@@ -60,6 +58,9 @@ Function Get-VirtualServer{
                 If ($Address){
                     $items = $items | Where-Object {$_.Destination -match $Address}
                 }
+
+<#
+    JN: the expandSubcollections=true param should be a better way to expand subcollections and so this subcollection expansion logic wouldn't be needed.
 
                 #Unless requested subcollections will be included
                 #Excluding subcollections has a significant performance increase
@@ -97,7 +98,7 @@ Function Get-VirtualServer{
                         }
                     }
                 } #End of subcollection gathering
-
+#>
                 $items | Add-ObjectDetail -TypeName 'PoshLTM.VirtualServer'
             }
         }

--- a/F5-LTM/Public/Test-F5Session.ps1
+++ b/F5-LTM/Public/Test-F5Session.ps1
@@ -5,10 +5,14 @@ Function Test-F5Session {
 #>
     [cmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)][AllowNull()]$F5Session
+        $F5Session=$Script:F5Session
     )
     #Validate F5Session 
     If ($($F5Session.BaseURL) -ne ("https://$($F5Session.Name)/mgmt/tm/ltm/") -or ($F5Session.WebSession.GetType().name -ne 'WebRequestSession')) { 
         Write-Error 'You must either create an F5 Session with script scope (by calling New-F5Session) or pass an F5 session to this function.' 
     }
+# JN: Currently this function returns nothing if successful, which doesn't seem correct. However, if it returned true, all functions that call it would need to suppress the returned value
+#    Else {
+#        Return($true)
+#    }
 }


### PR DESCRIPTION
…ession if no F5session is passed in. Made a note about possibly returning $true for a successful result on Test-F5Session. For Get-VirtualServer, modified it to use the expandSubcollections=true param as a quicker and more elegant way to expand subcollections for large numbers of virtual servers.