### PR TITLE
Eliminates future changes needed to Resolve-NestedStats for new versions of LTM

### DIFF
--- a/F5-LTM/Private/Resolve-NestedStats.ps1
+++ b/F5-LTM/Private/Resolve-NestedStats.ps1
@@ -14,10 +14,7 @@
     )
     switch ($F5Session.LTMVersion.Major)
     {
-        11 { <# no conversion needed #> }
-        12 { $JSON = $JSON.entries.PSObject.Properties.Value.nestedStats; }
-        13 { $JSON = $JSON.entries.PSObject.Properties.Value.nestedStats; }
-        14 { $JSON = $JSON.entries.PSObject.Properties.Value.nestedStats; }
+        { $_ -gt 11 } { $JSON = $JSON.entries.PSObject.Properties.Value.nestedStats; }
         Default { <# assume no conversion needed #> }
     }
 


### PR DESCRIPTION
This uses the new JSON parsing for all versions greater than 11, eliminating the need for continual changes.

https://github.com/joel74/POSH-LTM-Rest/issues/203