### PR TITLE
Added a new function to Remove F5 Session and release token

### DIFF
--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -84,6 +84,7 @@
             BaseURL = $BaseURL
             Credential = $Credential
             WebSession = $session
+			Token      = $Token
         } | Add-Member -Name GetLink -MemberType ScriptMethod {
                 param($Link)
                 $Link -replace 'localhost', $this.Name    

--- a/F5-LTM/Public/New-F5Session.ps1
+++ b/F5-LTM/Public/New-F5Session.ps1
@@ -79,16 +79,17 @@
         $Credential = $LTMCredentials
     }
 
-    $newSession = [pscustomobject]@{
-            Name = $LTMName
-            BaseURL = $BaseURL
+     $newSession = [pscustomobject]@{
+            Name       = $LTMName
+            BaseURL    = $BaseURL
             Credential = $Credential
             WebSession = $session
-			Token      = $Token
+            Token      = $Token
         } | Add-Member -Name GetLink -MemberType ScriptMethod {
                 param($Link)
                 $Link -replace 'localhost', $this.Name    
     } -PassThru 
+
 
 
     # Since we've connected to the LTM, we can now retrieve the device version

--- a/F5-LTM/Public/Remove-F5Session.ps1
+++ b/F5-LTM/Public/Remove-F5Session.ps1
@@ -1,33 +1,44 @@
 Function Remove-F5Session {
-    <#
-    .SYNOPSIS
-        Remove F5 session based on the token
-    #>
+<#
+.SYNOPSIS
+    Remove F5 session based on the token
+#>
     [cmdletBinding()]
     param (
         $F5Session = $Script:F5Session,
-        [switch]$SkipCertifcateCheck
+        [switch]$SkipCertificateCheck
     )
     #Validate F5Session 
     Test-F5Session($F5Session)
+
+    try {
     
-    if ($SkipCertifcateCheck) {
+        if ($SkipCertificateCheck) {
 
-        if ($PSVersionTable.PSVersion.Major -ge 6) {
+            if ($PSVersionTable.PSVersion.Major -ge 6) {
 
-            $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE -SkipCertificateCheck
+                $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE -SkipCertificateCheck -ErrorVariable LTMError
+            }
+            else {
+
+                [SSLValidator]::OverrideValidation()
+                $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE -ErrorVariable LTMError
+                [SSLValidator]::RestoreValidation()
+            }
         }
         else {
 
-            [SSLValidator]::OverrideValidation()
-            $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE
-            [SSLValidator]::RestoreValidation()
+            $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE -ErrorVariable LTMError
         }
-    }
-    else {
 
-        $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE
+        Write-Verbose "Session : token $($RemoveSession.token) deleted"
+        Return($true)
     }
 
-    Write-Verbose "Session : token $($RemoveSession.token) deleted"
+    catch {
+
+        $ErrorMessage = $LTMError[0].message;
+        Throw ("We failed to remove the specified session. The error was: $ErrorMessage")
+
+    }
 }

--- a/F5-LTM/Public/Remove-F5Session.ps1
+++ b/F5-LTM/Public/Remove-F5Session.ps1
@@ -19,19 +19,9 @@ Function Remove-F5Session {
         }
         else {
 
-            add-type @"
-        using System.Net;
-        using System.Security.Cryptography.X509Certificates;
-        public class TrustAllCertsPolicy : ICertificatePolicy {
-            public bool CheckValidationResult(
-                ServicePoint srvPoint, X509Certificate certificate,
-                WebRequest request, int certificateProblem) {
-                return true;
-            }
-        }
-"@
-            [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+            [SSLValidator]::OverrideValidation()
             $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE
+            [SSLValidator]::RestoreValidation()
         }
     }
     else {

--- a/F5-LTM/Public/Remove-F5Session.ps1
+++ b/F5-LTM/Public/Remove-F5Session.ps1
@@ -1,0 +1,43 @@
+Function Remove-F5Session {
+    <#
+    .SYNOPSIS
+        Remove F5 session based on the token
+    #>
+    [cmdletBinding()]
+    param (
+        $F5Session = $Script:F5Session,
+        [switch]$SkipCertifcateCheck
+    )
+    #Validate F5Session 
+    Test-F5Session($F5Session)
+    
+    if ($SkipCertifcateCheck) {
+
+        if ($PSVersionTable.PSVersion.Major -ge 6) {
+
+            $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE -SkipCertificateCheck
+        }
+        else {
+
+            add-type @"
+        using System.Net;
+        using System.Security.Cryptography.X509Certificates;
+        public class TrustAllCertsPolicy : ICertificatePolicy {
+            public bool CheckValidationResult(
+                ServicePoint srvPoint, X509Certificate certificate,
+                WebRequest request, int certificateProblem) {
+                return true;
+            }
+        }
+"@
+            [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+            $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE
+        }
+    }
+    else {
+
+        $RemoveSession = Invoke-RestMethod "https://$($F5Session.name)/mgmt/shared/authz/tokens/$($F5Session.token)" -Headers @{'X-F5-Auth-Token' = $F5Session.token } -Method DELETE
+    }
+
+    Write-Verbose "Session : token $($RemoveSession.token) deleted"
+}

--- a/F5-LTM/Public/Remove-F5Session.ps1
+++ b/F5-LTM/Public/Remove-F5Session.ps1
@@ -32,6 +32,7 @@ Function Remove-F5Session {
         }
 
         Write-Verbose "Session : token $($RemoveSession.token) deleted"
+        Remove-Variable F5Session -Scope Script
         Return($true)
     }
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The module contains the following functions.
    * New-ProfileHttp
    * New-VirtualServer
    * Remove-Application
+   * Remove-F5Session
    * Remove-HealthMonitor
    * Remove-iRule
    * Remove-iRuleFromVirtualServer


### PR DESCRIPTION
Hi,
I use this module as part of a monitoring which calls New-F5Session several dozen times, however I was getting an error about maximum logins tokens reached.
This is because our production F5 has a limitation on the number of sessions available, I don't know if we can configure this... So I found it interesting to create a new **Remove-F5Session** function in order to overcome this problem and release tokens faster than their expiration time.