### PR TITLE
Fixing collision with Definition property

### DIFF
--- a/F5-LTM/Public/Get-iRule.ps1
+++ b/F5-LTM/Public/Get-iRule.ps1
@@ -35,7 +35,7 @@
                 if(![string]::IsNullOrWhiteSpace($Application) -and ![string]::IsNullOrWhiteSpace($Partition)) {
                     $items = $items | Where-Object {$_.fullPath -eq "/$($_.partition)/$Application.app/$($_.name)"}
                 }
-                $items | Add-ObjectDetail -TypeName 'PoshLTM.iRule' | Add-Member -MemberType AliasProperty -Name Definition -Value apiAnonymous;
+                $items | Add-ObjectDetail -TypeName 'PoshLTM.iRule' | Add-Member -MemberType AliasProperty -Name iRuleContent -Value apiAnonymous;
                 $items
             }
         }


### PR DESCRIPTION
There is a default property in the iRule object called Definition. This was causing collision so I renamed the property with the iRule definition to iRuleContent