### PR TITLE
Conditionally adds Validation.cs

### DIFF
--- a/F5-LTM/F5-LTM.psm1
+++ b/F5-LTM/F5-LTM.psm1
@@ -14,7 +14,11 @@
 
 $Script:F5Session=$null
 
-Add-Type -Path "${PSScriptRoot}\Validation.cs"
+ if ($PSVersionTable.PSVersion.Major -ge 6) {
+    Add-Type -Path "${PSScriptRoot}\Validation.cs"
+ }
+
+
 #Only add this type if it isn't already added to the session
 if (!("PoshLTM.F5Address" -as [type])) {
     Add-Type -Path "${PSScriptRoot}\TypeData\PoshLTM.Types.cs"

--- a/F5-LTM/F5-LTM.psm1
+++ b/F5-LTM/F5-LTM.psm1
@@ -14,7 +14,7 @@
 
 $Script:F5Session=$null
 
- if ($PSVersionTable.PSVersion.Major -ge 6) {
+ if ($PSVersionTable.PSVersion.Major -lt 6) {
     Add-Type -Path "${PSScriptRoot}\Validation.cs"
  }
 

--- a/F5-LTM/F5-LTM.psm1
+++ b/F5-LTM/F5-LTM.psm1
@@ -18,7 +18,6 @@ $Script:F5Session=$null
     Add-Type -Path "${PSScriptRoot}\Validation.cs"
  }
 
-
 #Only add this type if it isn't already added to the session
 if (!("PoshLTM.F5Address" -as [type])) {
     Add-Type -Path "${PSScriptRoot}\TypeData\PoshLTM.Types.cs"


### PR DESCRIPTION
Ensures Validation.cs is only added when running on PowerShell version 6 or greater. This avoids issues on older PowerShell versions where the Add-Type command might fail.


That validation is used only in older versions of Powershell and is not necessary in greater than 6 version. It's also caused an error in environment that uses .NET in version greater or equal version 6.
ServicePointManager is no longer supported: https://github.com/dotnet/docs/issues/43144
